### PR TITLE
feat: beautify UI — indigo theme, message cards, multiline editor

### DIFF
--- a/.agents/skills/storybook-setup/SKILL.md
+++ b/.agents/skills/storybook-setup/SKILL.md
@@ -1,0 +1,616 @@
+---
+name: storybook-setup
+description: Sets up Storybook for component documentation with controls, actions, accessibility testing, and visual regression. Use when users request "Storybook setup", "component documentation", "UI library", "component stories", or "design system docs".
+---
+
+# Storybook Setup
+
+Configure Storybook for comprehensive component documentation and testing.
+
+## Core Workflow
+
+1. **Initialize Storybook**: Setup with framework
+2. **Configure addons**: Controls, actions, a11y
+3. **Write stories**: Document components
+4. **Add documentation**: MDX pages
+5. **Setup testing**: Visual regression
+6. **Deploy docs**: Static hosting
+
+## Installation
+
+```bash
+# Initialize Storybook
+npx storybook@latest init
+
+# Or with specific framework
+npx storybook@latest init --type react
+npx storybook@latest init --type nextjs
+npx storybook@latest init --type vue3
+```
+
+## Configuration
+
+### Main Configuration
+
+```typescript
+// .storybook/main.ts
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: [
+    '../src/**/*.mdx',
+    '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
+    '@storybook/addon-a11y',
+    '@storybook/addon-designs',
+    '@storybook/addon-coverage',
+  ],
+
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+
+  docs: {
+    autodocs: 'tag',
+  },
+
+  staticDirs: ['../public'],
+
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      shouldRemoveUndefinedFromOptional: true,
+      propFilter: (prop) =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
+    },
+  },
+
+  viteFinal: async (config) => {
+    // Customize Vite config
+    return config;
+  },
+};
+
+export default config;
+```
+
+### Preview Configuration
+
+```typescript
+// .storybook/preview.ts
+import type { Preview } from '@storybook/react';
+import { themes } from '@storybook/theming';
+import '../src/styles/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#ffffff' },
+        { name: 'dark', value: '#1a1a1a' },
+        { name: 'gray', value: '#f5f5f5' },
+      ],
+    },
+    layout: 'centered',
+    docs: {
+      theme: themes.light,
+    },
+    a11y: {
+      config: {
+        rules: [
+          { id: 'color-contrast', enabled: true },
+          { id: 'label', enabled: true },
+        ],
+      },
+    },
+    viewport: {
+      viewports: {
+        mobile: {
+          name: 'Mobile',
+          styles: { width: '375px', height: '667px' },
+        },
+        tablet: {
+          name: 'Tablet',
+          styles: { width: '768px', height: '1024px' },
+        },
+        desktop: {
+          name: 'Desktop',
+          styles: { width: '1440px', height: '900px' },
+        },
+      },
+    },
+  },
+  globalTypes: {
+    theme: {
+      description: 'Global theme',
+      defaultValue: 'light',
+      toolbar: {
+        title: 'Theme',
+        icon: 'circlehollow',
+        items: ['light', 'dark'],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const theme = context.globals.theme;
+      return (
+        <div className={theme === 'dark' ? 'dark' : ''}>
+          <div className="bg-white dark:bg-gray-900 p-4">
+            <Story />
+          </div>
+        </div>
+      );
+    },
+  ],
+};
+
+export default preview;
+```
+
+## Writing Stories
+
+### Component Story Format (CSF3)
+
+```typescript
+// src/components/Button/Button.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'A versatile button component with multiple variants and sizes.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'outline', 'ghost'],
+      description: 'Visual style variant',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'primary' },
+      },
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+      description: 'Button size',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable the button',
+    },
+    loading: {
+      control: 'boolean',
+      description: 'Show loading state',
+    },
+    children: {
+      control: 'text',
+      description: 'Button content',
+    },
+  },
+  args: {
+    onClick: fn(),
+    children: 'Button',
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic stories
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    variant: 'outline',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+  },
+};
+
+// Size variants
+export const Small: Story = {
+  args: {
+    size: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+  },
+};
+
+// States
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};
+
+// With icons
+export const WithIcon: Story = {
+  args: {
+    children: (
+      <>
+        <PlusIcon className="mr-2 h-4 w-4" />
+        Add Item
+      </>
+    ),
+  },
+};
+
+// All variants showcase
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Button variant="primary">Primary</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="ghost">Ghost</Button>
+    </div>
+  ),
+};
+```
+
+### Interactive Stories
+
+```typescript
+// src/components/Form/Form.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, userEvent, expect, fn } from '@storybook/test';
+import { Form } from './Form';
+
+const meta: Meta<typeof Form> = {
+  title: 'Components/Form',
+  component: Form,
+  args: {
+    onSubmit: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FilledForm: Story = {
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    // Fill out the form
+    const emailInput = canvas.getByLabelText('Email');
+    await userEvent.type(emailInput, 'test@example.com', { delay: 50 });
+
+    const passwordInput = canvas.getByLabelText('Password');
+    await userEvent.type(passwordInput, 'password123', { delay: 50 });
+
+    // Submit the form
+    const submitButton = canvas.getByRole('button', { name: /submit/i });
+    await userEvent.click(submitButton);
+
+    // Assert the form was submitted
+    await expect(args.onSubmit).toHaveBeenCalled();
+  },
+};
+
+export const ValidationError: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Submit without filling
+    const submitButton = canvas.getByRole('button', { name: /submit/i });
+    await userEvent.click(submitButton);
+
+    // Check for error messages
+    await expect(canvas.getByText('Email is required')).toBeInTheDocument();
+  },
+};
+```
+
+### MDX Documentation
+
+```mdx
+{/* src/components/Button/Button.mdx */}
+import { Meta, Story, Canvas, Controls, ArgTypes } from '@storybook/blocks';
+import * as ButtonStories from './Button.stories';
+import { Button } from './Button';
+
+<Meta of={ButtonStories} />
+
+# Button
+
+The Button component is used to trigger actions or navigation.
+
+## Import
+
+```tsx
+import { Button } from '@/components/Button';
+```
+
+## Usage
+
+<Canvas of={ButtonStories.Primary} />
+
+## Variants
+
+Buttons come in four variants to communicate different levels of emphasis.
+
+<Canvas>
+  <Story of={ButtonStories.AllVariants} />
+</Canvas>
+
+### Primary
+Use for primary actions that are the main call to action on a page.
+
+### Secondary
+Use for secondary actions that complement the primary action.
+
+### Outline
+Use for tertiary actions or when you want less visual emphasis.
+
+### Ghost
+Use for navigation or very subtle actions.
+
+## Sizes
+
+<Canvas>
+  <div className="flex items-center gap-4">
+    <Button size="sm">Small</Button>
+    <Button size="md">Medium</Button>
+    <Button size="lg">Large</Button>
+  </div>
+</Canvas>
+
+## States
+
+### Disabled
+
+<Canvas of={ButtonStories.Disabled} />
+
+### Loading
+
+<Canvas of={ButtonStories.Loading} />
+
+## Props
+
+<ArgTypes of={Button} />
+
+## Accessibility
+
+- Buttons use the native `<button>` element
+- Loading state announces to screen readers
+- Focus states are clearly visible
+- Disabled buttons maintain proper ARIA attributes
+
+## Design Guidelines
+
+1. Use descriptive button text
+2. Limit to one primary button per section
+3. Keep button text concise (2-4 words)
+4. Use icons to reinforce meaning, not replace text
+```
+
+## Testing Integration
+
+### Visual Regression with Chromatic
+
+```typescript
+// .storybook/main.ts
+const config: StorybookConfig = {
+  addons: [
+    '@chromatic-com/storybook',
+  ],
+};
+```
+
+```json
+// package.json
+{
+  "scripts": {
+    "chromatic": "chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
+  }
+}
+```
+
+### Test Runner
+
+```bash
+npm install @storybook/test-runner -D
+```
+
+```typescript
+// .storybook/test-runner.ts
+import type { TestRunnerConfig } from '@storybook/test-runner';
+import { getStoryContext } from '@storybook/test-runner';
+import { injectAxe, checkA11y } from 'axe-playwright';
+
+const config: TestRunnerConfig = {
+  async preVisit(page) {
+    await injectAxe(page);
+  },
+  async postVisit(page, context) {
+    // Run accessibility tests
+    const storyContext = await getStoryContext(page, context);
+    if (!storyContext.parameters?.a11y?.disable) {
+      await checkA11y(page, '#storybook-root', {
+        detailedReport: true,
+        detailedReportOptions: { html: true },
+      });
+    }
+  },
+};
+
+export default config;
+```
+
+```json
+// package.json
+{
+  "scripts": {
+    "test-storybook": "test-storybook",
+    "test-storybook:ci": "test-storybook --ci"
+  }
+}
+```
+
+## Design Tokens Integration
+
+```typescript
+// .storybook/preview.ts
+import { ThemeProvider } from 'styled-components';
+import { theme } from '../src/styles/theme';
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+```
+
+```typescript
+// src/styles/theme.ts (document in Storybook)
+export const theme = {
+  colors: {
+    primary: {
+      50: '#eff6ff',
+      500: '#3b82f6',
+      900: '#1e3a8a',
+    },
+  },
+  spacing: {
+    xs: '0.25rem',
+    sm: '0.5rem',
+    md: '1rem',
+    lg: '1.5rem',
+    xl: '2rem',
+  },
+  radii: {
+    sm: '0.25rem',
+    md: '0.375rem',
+    lg: '0.5rem',
+    full: '9999px',
+  },
+};
+```
+
+## Publishing
+
+### Static Export
+
+```json
+// package.json
+{
+  "scripts": {
+    "build-storybook": "storybook build",
+    "storybook:serve": "npx http-server storybook-static"
+  }
+}
+```
+
+### GitHub Pages
+
+```yaml
+# .github/workflows/storybook.yml
+name: Deploy Storybook
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build-storybook
+
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./storybook-static
+```
+
+## Best Practices
+
+1. **One component per file**: Clear organization
+2. **Use autodocs**: Generate documentation
+3. **Add controls**: Interactive exploration
+4. **Include a11y addon**: Accessibility testing
+5. **Write play functions**: Interactive tests
+6. **Document with MDX**: Rich documentation
+7. **Use decorators**: Consistent context
+8. **Visual regression**: Catch UI changes
+
+## Output Checklist
+
+Every Storybook setup should include:
+
+- [ ] Main configuration with addons
+- [ ] Preview with global decorators
+- [ ] Stories in CSF3 format
+- [ ] Autodocs enabled
+- [ ] Controls for all props
+- [ ] Accessibility addon
+- [ ] Dark mode support
+- [ ] Viewport presets
+- [ ] MDX documentation
+- [ ] Test runner setup
+- [ ] CI deployment
+- [ ] Static build script

--- a/.agents/skills/storybook-stories/SKILL.md
+++ b/.agents/skills/storybook-stories/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: storybook-stories
+description: Create, update, or refactor Storybook stories following the project's standard patterns. Use when adding stories for new components, updating existing stories, or fixing Storybook-related issues. Don't use for component implementation itself, design-system token changes, end-to-end browser tests, or non-Storybook documentation.
+metadata:
+  author: Pedro Nauck
+  github: https://github.com/pedronauck
+  repository: https://github.com/pedronauck/skills
+---
+# Storybook Stories
+
+This skill enforces consistent Storybook story creation patterns across the application. It ensures that all components have proper documentation, interactive examples, and follow the established project structure.
+
+<critical_component_usage>
+**MANDATORY: Always Use Base UI Components from @agh/ui**
+
+**CRITICAL REQUIREMENTS:**
+
+- ✅ **ALWAYS** import components from `@agh/ui` package (`packages/ui`)
+- ✅ **ALWAYS** use existing base UI components instead of creating new ones from scratch
+- ✅ **ALWAYS** follow design system rules from `@.cursor/rules/react.mdc` and `@.cursor/rules/shadcn.mdc`
+- ✅ **ALWAYS** use design tokens (e.g., `bg-background`, `text-foreground`, `border-border`) instead of explicit colors
+- ❌ **NEVER** create components from scratch when a base component exists in `@agh/ui`
+- ❌ **NEVER** use explicit color values (e.g., `bg-white`, `text-black`) - always use design tokens
+- ❌ **NEVER** duplicate component logic - compose from base components
+- ❌ **NEVER** set `tags: ["autodocs"]` or enable Storybook autodocs on any story meta (`packages/ui`, `web/src/components/ui`, or `web/src/systems/**`). Use `parameters.docs.description.component`, JSDoc on stories, and the Docs addon manually if needed.
+
+**Available Base Components:**
+All components from `packages/ui/src/components` are available via `@agh/ui`:
+
+- Button, Card, Dialog, Input, Select, Badge, Avatar, Accordion, Alert, etc.
+- See `packages/ui/src/index.ts` for complete list of exports
+
+**Design System Rules:**
+
+- Follow React best practices: `@.cursor/rules/react.mdc`
+- Follow Shadcn UI patterns: `@.cursor/rules/shadcn.mdc`
+- Use design tokens for theming: `bg-background`, `text-foreground`, `border-border`, etc.
+  </critical_component_usage>
+
+## Instructions
+
+1. **File Location & Naming**
+   - Place story files in a `stories/` folder within the same category folder as the component.
+   - Example: `src/components/base/accordion.tsx` -> `src/components/base/stories/accordion.stories.tsx`.
+   - Use the Storybook instance that matches the layer:
+     - `packages/ui/.storybook` for `packages/ui/src/components/*.stories.tsx`
+     - `web/.storybook` for `web/src/components/ui/**/*.stories.tsx` and `web/src/systems/**/components/stories/*.stories.tsx`
+
+2. **Component Imports**
+   - **MANDATORY**: Import base UI components from `@agh/ui`
+   - Use: `import { Button, Card, Dialog } from "@agh/ui";`
+   - Only import custom/domain-specific components from local files
+   - Check `packages/ui/src/index.ts` to see available components before creating new ones
+
+3. **Meta Configuration**
+   - Title should follow the directory structure: `components/custom/ComponentName` or `components/ui/ComponentName`.
+   - Include `component` in the meta object.
+   - Set `parameters.layout` to `"centered"` by default.
+   - Add `parameters.docs.description.component` to describe the component.
+   - Use `decorators` if the component requires a specific container width or context.
+   - **MANDATORY**: Use explicit type annotation: `const meta: Meta<typeof Component> = { ... }`
+   - **MANDATORY**: Do not add `tags: ["autodocs"]` to meta (any layer). Autodocs inflates generated docs noise and is forbidden in this repo.
+   - `web` system stories may rely on the shared QueryClient + router + MSW decorators from `web/.storybook/preview.ts`; prefer those global decorators over per-story provider duplication.
+
+4. **Story Definition**
+   - Define a helper type: `type Story = StoryObj<typeof meta>;`.
+   - Export stories as named constants (PascalCase).
+   - Always add JSDoc comments above each story export; these appear in the Storybook UI.
+   - Use the `Default` story as the primary example.
+   - **MANDATORY**: All stories must include `args` property, even if empty: `args: {}`
+   - **Keep it concise**: Create only essential stories (2-5 max per component). Avoid over-engineering with excessive variations or complex scenarios.
+   - For system stories, keep titles aligned to the domain surface: `systems/<name>/<ComponentName>`.
+
+5. **Render vs Args**
+   - Use `render` functions for compound components (like Accordion, Dialog, Select) that require children composition.
+   - Use `args` for simple components (like Button, Badge) where props define the variation.
+   - **MANDATORY**: Even when using `render`, include `args: {}` property
+
+6. **Design System Compliance**
+   - **ALWAYS** use design tokens for colors: `bg-background`, `text-foreground`, `border-border`
+   - **NEVER** use explicit colors: `bg-white`, `text-black`, `border-gray-200`
+   - Follow accessibility guidelines from `@.cursor/rules/shadcn.mdc`
+   - Use semantic HTML elements and proper ARIA attributes
+
+## Example Template
+
+### Using Base UI Components from @agh/ui
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button, Card, CardHeader, CardTitle, CardContent } from "@agh/ui";
+import { MyCustomComponent } from "./my-custom-component";
+
+const meta: Meta<typeof MyCustomComponent> = {
+  title: "components/custom/MyCustomComponent",
+  component: MyCustomComponent,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "A custom component that composes base UI components from @agh/ui.",
+      },
+    },
+  },
+  // Optional decorator using design tokens
+  decorators: [
+    Story => (
+      <div className="w-[400px] p-4 bg-background border border-border rounded-lg">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default usage showing the standard behavior
+ * Uses base Button and Card components from @agh/ui
+ */
+export const Default: Story = {
+  args: {},
+  render: () => (
+    <Card>
+      <CardHeader>
+        <CardTitle>My Custom Component</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <MyCustomComponent>
+          <Button variant="default">Action</Button>
+        </MyCustomComponent>
+      </CardContent>
+    </Card>
+  ),
+};
+
+/**
+ * Variation with specific props
+ * All styling uses design tokens (bg-background, text-foreground, etc.)
+ */
+export const WithVariant: Story = {
+  args: {},
+  render: () => (
+    <div className="bg-card border border-border rounded-lg p-4">
+      <MyCustomComponent variant="secondary">
+        <Button variant="outline">Secondary Action</Button>
+      </MyCustomComponent>
+    </div>
+  ),
+};
+```
+
+### Story for Base UI Component (from @agh/ui)
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@agh/ui";
+
+const meta: Meta<typeof Button> = {
+  title: "components/ui/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "A button component with multiple variants and sizes.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default button with standard styling
+ */
+export const Default: Story = {
+  args: {
+    children: "Button",
+    variant: "default",
+    size: "default",
+  },
+};
+
+/**
+ * All variants using design tokens
+ */
+export const AllVariants: Story = {
+  args: {},
+  render: () => (
+    <div className="flex flex-wrap gap-4 bg-background p-4 rounded-lg">
+      <Button variant="default">Default</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="muted">Muted</Button>
+    </div>
+  ),
+};
+```
+
+## Best Practices
+
+### Autodocs (forbidden)
+
+**Do not use Storybook autodocs.** Never set `tags: ["autodocs"]` on `meta` for `packages/ui`, `web/src/components/ui`, or `web/src/systems/**` stories. Rationale: autodocs-generated pages add noise and duplicate what we already express with concise stories, `parameters.docs.description.component`, and per-story JSDoc. If a component needs richer prose, write it in the description fields and keep the canvas as the source of truth.
+
+### Conciseness & Simplicity
+
+<critical>
+**MANDATORY: Keep Stories Concise and Focused**
+
+- ✅ **DO**: Create only essential stories that demonstrate core functionality
+- ✅ **DO**: Use minimal, realistic examples that show the component's purpose
+- ✅ **DO**: Focus on one concept per story
+- ❌ **DON'T**: Create excessive variations that don't add value
+- ❌ **DON'T**: Over-engineer with complex mock data or elaborate scenarios
+- ❌ **DON'T**: Create stories for every possible prop combination
+- ❌ **DON'T**: Add unnecessary decorators or wrappers unless required
+
+**Story Count Guidelines:**
+
+- Simple components (Button, Badge): 2-3 stories max (Default + 1-2 key variations)
+- Medium components (Card, Dialog): 3-4 stories max (Default + key use cases)
+- Complex components: 4-5 stories max (Default + essential scenarios)
+- **Never create more than 5 stories per component** unless absolutely necessary
+  </critical>
+
+### Component Usage
+
+- **Base Components First**: Always check `@agh/ui` for existing components before creating new ones
+- **Composition Over Creation**: Compose complex components from base UI components
+- **Compound Components**: Always demonstrate the full structure (Parent + Children) when using compound components from `@agh/ui`
+- **Design Tokens**: Always use design tokens (`bg-background`, `text-foreground`, etc.) instead of explicit colors
+
+### Story Structure
+
+- **Mock Data**: Keep mock data minimal and realistic - only include what's necessary to demonstrate the component
+- **Interactivity**: For components like Accordion or Dialog, ensure the `render` function sets up the component in a way that allows interaction (e.g., not force-controlled unless necessary)
+- **Cleanliness**: Remove unused imports and generic "template" comments
+- **Type Safety**: Always use explicit type annotation for `meta`: `const meta: Meta<typeof Component>`
+- **Args Property**: Always include `args: {}` in all stories, even when using custom `render` functions
+- **One Story Per Concept**: Each story should demonstrate one clear use case or variation, not multiple concepts
+
+### Design System Compliance
+
+- **Follow React Rules**: Adhere to patterns in `@.cursor/rules/react.mdc`
+- **Follow Shadcn Rules**: Adhere to patterns in `@.cursor/rules/shadcn.mdc`
+- **Accessibility**: Use semantic HTML and proper ARIA attributes
+- **Theme Support**: All stories should work in both light and dark themes using design tokens
+
+## Common Mistakes to Avoid
+
+❌ **Creating components from scratch when base components exist:**
+
+```tsx
+// ❌ BAD: Creating a button from scratch
+export const Bad: Story = {
+  render: () => <button className="bg-blue-500 text-white px-4 py-2 rounded">Click me</button>,
+};
+
+// ✅ GOOD: Using base Button from @agh/ui
+import { Button } from "@agh/ui";
+export const Good: Story = {
+  args: {},
+  render: () => <Button variant="default">Click me</Button>,
+};
+```
+
+❌ **Enabling autodocs on meta:**
+
+```tsx
+// ❌ BAD: autodocs tag (forbidden in this repo)
+const meta: Meta<typeof Button> = {
+  title: "ui/Button",
+  component: Button,
+  tags: ["autodocs"],
+};
+
+// ✅ GOOD: no autodocs tag; describe the component in parameters.docs
+const meta: Meta<typeof Button> = {
+  title: "ui/Button",
+  component: Button,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "Primary action button with variants and sizes.",
+      },
+    },
+  },
+};
+```
+
+❌ **Using explicit colors instead of design tokens:**
+
+```tsx
+// ❌ BAD: Using explicit colors
+<div className="bg-white text-black border-gray-200">
+
+// ✅ GOOD: Using design tokens
+<div className="bg-background text-foreground border-border">
+```
+
+❌ **Missing args property:**
+
+```tsx
+// ❌ BAD: Missing args property
+export const Bad: Story = {
+  render: () => <Button>Click</Button>,
+};
+
+// ✅ GOOD: Including args property
+export const Good: Story = {
+  args: {},
+  render: () => <Button>Click</Button>,
+};
+```
+
+❌ **Missing explicit type annotation:**
+
+```tsx
+// ❌ BAD: Type inference
+const meta = {
+  title: "Components/Button",
+  component: Button,
+} satisfies Meta<typeof Button>;
+
+// ✅ GOOD: Explicit type annotation
+const meta: Meta<typeof Button> = {
+  title: "Components/Button",
+  component: Button,
+};
+```
+
+❌ **Over-engineering stories with unnecessary examples:**
+
+```tsx
+// ❌ BAD: Too many stories with similar variations
+export const Default: Story = { ... };
+export const WithIcon: Story = { ... };
+export const WithIconLeft: Story = { ... };
+export const WithIconRight: Story = { ... };
+export const WithLongText: Story = { ... };
+export const WithShortText: Story = { ... };
+export const Disabled: Story = { ... };
+export const Loading: Story = { ... };
+export const WithTooltip: Story = { ... };
+export const InCard: Story = { ... };
+export const InDialog: Story = { ... };
+// ... 10+ stories for a simple button
+
+// ✅ GOOD: Concise, focused stories
+export const Default: Story = {
+  args: {
+    children: "Button",
+    variant: "default",
+  },
+};
+
+export const Variants: Story = {
+  args: {},
+  render: () => (
+    <div className="flex gap-2">
+      <Button variant="default">Default</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="outline">Outline</Button>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Disabled",
+    disabled: true,
+  },
+};
+// Only 3 stories covering essential use cases
+```
+
+❌ **Over-complicated mock data or scenarios:**
+
+```tsx
+// ❌ BAD: Unnecessarily complex mock data
+const mockUsers = [
+  { id: "1", name: "John Doe", email: "john@example.com", role: "admin", avatar: "...", lastLogin: "...", permissions: [...], metadata: {...} },
+  { id: "2", name: "Jane Smith", email: "jane@example.com", role: "user", avatar: "...", lastLogin: "...", permissions: [...], metadata: {...} },
+  // ... 10 more users with full data
+];
+
+// ✅ GOOD: Minimal, realistic data
+const mockUsers = [
+  { id: "1", name: "John Doe", email: "john@example.com" },
+  { id: "2", name: "Jane Smith", email: "jane@example.com" },
+];
+```

--- a/.agents/skills/storybook-stories/references/patterns.md
+++ b/.agents/skills/storybook-stories/references/patterns.md
@@ -1,0 +1,60 @@
+# Storybook Patterns Reference
+
+## Accordion Pattern (Compound Component)
+
+Compound components require a `render` function to structure the children correctly.
+
+```tsx
+export const Default: Story = {
+  render: () => (
+    <Accordion>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Is it accessible?</AccordionTrigger>
+        <AccordionContent>Yes. It adheres to the WAI-ARIA design pattern.</AccordionContent>
+      </AccordionItem>
+      {/* More items... */}
+    </Accordion>
+  ),
+};
+```
+
+## Simple Component Pattern (Props-based)
+
+Simple components can often just use `args`.
+
+```tsx
+export const Default: Story = {
+  args: {
+    variant: "default",
+    size: "md",
+    children: "Button Text",
+  },
+};
+```
+
+## Wrapped Component Pattern
+
+Sometimes a component needs a wrapper to look right in the centered layout (e.g., a Toast or a large Card).
+
+```tsx
+decorators: [
+  (Story) => (
+    <div className="w-[400px] p-4 border rounded">
+      <Story />
+    </div>
+  ),
+],
+```
+
+## Interactive/Stateful Pattern
+
+For components that might need internal state control in stories (though Storybook controls often handle this), you can use standard React hooks inside the render function if absolutely necessary, but usually, uncontrolled primitives are preferred for display.
+
+```tsx
+export const Interactive: Story = {
+  render: () => {
+    // ... implementation
+    return <Component />;
+  },
+};
+```

--- a/.claude/skills/storybook-setup
+++ b/.claude/skills/storybook-setup
@@ -1,0 +1,1 @@
+../../.agents/skills/storybook-setup

--- a/.claude/skills/storybook-stories
+++ b/.claude/skills/storybook-stories
@@ -1,0 +1,1 @@
+../../.agents/skills/storybook-stories

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+*storybook.log
+storybook-static

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,13 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: [
+    '@storybook/addon-a11y',
+    '@storybook/addon-docs',
+  ],
+  framework: '@storybook/react-vite',
+  staticDirs: ['../public'],
+};
+
+export default config;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,31 @@
+import type { Preview } from '@storybook/react-vite'
+import { initialize, mswLoader } from 'msw-storybook-addon'
+import '../src/index.css'
+import { attachmentUrlHandlers } from '../src/test-utils/mocks/attachmentUrlHandlers'
+
+initialize({ onUnhandledRequest: 'bypass' })
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+       color: /(background|color)$/i,
+       date: /Date$/i,
+      },
+    },
+
+    a11y: {
+      // 'todo' - show a11y violations in the test UI only
+      // 'error' - fail CI on a11y violations
+      // 'off' - skip a11y checks entirely
+      test: 'todo'
+    },
+
+    msw: {
+      handlers: attachmentUrlHandlers,
+    },
+  },
+  loaders: [mswLoader],
+};
+
+export default preview;

--- a/STORYBOOK_COVERAGE.md
+++ b/STORYBOOK_COVERAGE.md
@@ -1,0 +1,64 @@
+# Storybook coverage report
+
+Storybook was installed fresh for this repo (`@storybook/react-vite`, Vite 6 + React 19 + Tailwind v4). Scope for this pass is **stories only** — no test-runner, no Chromatic/visual regression, no `@storybook/addon-vitest`. Those were scaffolded by `storybook init` and deliberately removed to keep the install minimal; add them back later if the team wants automated story testing.
+
+All components under `src/pages/client/Chat` (plus `ChatPage.tsx` and `ClientLayout.tsx`) were triaged and either covered or explicitly postponed with the user's sign-off. Shared fixtures/decorators live in `src/test-utils/`.
+
+**Summary: 22 of 31 components covered (54 story variants), 9 postponed.**
+
+## Covered — Easy (12 components, pure presentational)
+
+| Component | Story file | Notes |
+|---|---|---|
+| ProgressBar | `ProgressBar/ProgressBar.stories.tsx` | 3 variants: mid-upload, just started, complete |
+| MessageThreadButton | `MessageThreadButton/MessageThreadButton.stories.tsx` | 3 variants: default, no replies, many replies |
+| MessageReaction | `MessageReaction/MessageReaction.stories.tsx` | Own vs. others' reaction |
+| MessageReactions | `MessageReactions/MessageReactions.stories.tsx` | With reactions, empty |
+| ReactionSelectionDialog | `ReactionSelectionDialog/ReactionSelectionDialog.stories.tsx` | Radix Popover/Tabs, full emoji list; with/without existing reactions |
+| EmojiSuggestionsPopup | `EmojiSuggestionsPopup/EmojiSuggestionsPopup.stories.tsx` | Query match, no query, no matches |
+| MessageUrlPreviewsComponent / MessageUrlPreviewComponent | `MessageUrlPreviewsComponent/*.stories.tsx` | Full preview, title-only, empty |
+| MessageAttachments | `MessageAttachments/MessageAttachments.stories.tsx` | Single, multiple, empty |
+| MessageAttachmentComponent | `MessageAttachmentComponent/MessageAttachmentComponent.stories.tsx` | image/gif/video/audio/binary variants; media previews render via an MSW redirect — see caveat below |
+| FullscreenPreview | `FullscreenPreview/FullscreenPreview.stories.tsx` | Image and video overlay |
+| **MessageComponent** (flagship) | `MessageComponent/MessageComponent.stories.tsx` | 7 variants: default, own message, with attachment, with reactions, edited, with thread, as reply |
+
+## Covered — Medium (6 components, side effects on interaction or a single mockable context/mutation)
+
+| Component | Story file | What's mocked |
+|---|---|---|
+| AudioAttachment | `AudioAttachment/AudioAttachment.stories.tsx` | Real sample audio URL for a working waveform; a broken-URL variant shows the graceful fallback (empty waveform, no throw) |
+| MessageInput | `MessageInput/MessageInput.stories.tsx` | Baseline states (empty, editing, replying) plus editing-while-a-reply-is-pending, which documents that the edit banner takes priority over the reply quote (see ChatMessageList.tsx wiring). Voice/video recording and real upload flows in its children are *not* exercised here (see VoiceRecorderModal/VideoRecorderModal below, and MessageEditorAttachment's skipped "pending" variant) |
+| MessageEditorAttachment | `MessageEditorAttachment/MessageEditorAttachment.stories.tsx` | "Uploaded" variant only (image + audio). The "pending" variant is **skipped** — it fires a real `uploadFileWithProgress` XHR in a `useEffect` on mount that can't be intercepted without a module-mocking addon (none installed in this pass) |
+| WorkspaceCreateModal | `WorkspaceCreateModal/WorkspaceCreateModal.stories.tsx` | `MockedProvider` with an `AddWorkspace` mutation mock |
+| ChannelsList | `ChannelsList/ChannelsList.stories.tsx` | `WorkspacesListContext` decorator; default + empty-channels variants. Opening "+ Create channel" mounts `CreateChannelModal`, which is covered separately below |
+| UserSettingsPopup | `UserSettingsPopup/UserSettingsPopup.stories.tsx` | `UserContext` decorator only |
+
+## Covered — Tricky (4 of 9, user chose full mock coverage)
+
+| Component | Story file | What's mocked |
+|---|---|---|
+| WorkspacesList | `WorkspacesList/WorkspacesList.stories.tsx` | `WorkspacesListContext` + `UserContext` decorators + `MockedProvider` (`AddWorkspace` mutation), so both the switcher and the nested create-workspace flow work end to end |
+| CreateChannelModal | `CreateChannelModal/CreateChannelModal.stories.tsx` | `WorkspacesListContext` + `ChannelTypesListContext` decorators + `MockedProvider` (`AddChannel` mutation) |
+| VoiceRecorderModal | `VoiceRecorderModal/VoiceRecorderModal.stories.tsx` | `navigator.mediaDevices.getUserMedia` patched to return a synthetic oscillator-generated audio `MediaStream` (see `src/test-utils/decorators/withFakeMediaDevices.tsx`), so the real `MediaRecorder` genuinely records. A `PermissionDenied` variant simulates a rejected permission prompt |
+| VideoRecorderModal | `VideoRecorderModal/VideoRecorderModal.stories.tsx` | Same technique using a canvas-captured synthetic video `MediaStream`. A `PermissionDenied` variant included |
+
+Both recorder-modal stories rely on `AudioContext.createMediaStreamDestination` / `HTMLCanvasElement.captureStream`, supported in all evergreen browsers; they haven't been validated in older/headless Chromium test runners.
+
+## Skipped / Postponed (5 components)
+
+| Component | Reason | What full coverage would need |
+|---|---|---|
+| ChatMessageList | Heaviest component in the tree: `useApolloClient`, `UserContext`, `WebSocketEventEmitter` subscriptions for 6 event types, 5+ GraphQL mutations, `IntersectionObserver`/`ResizeObserver` for scroll. User chose to postpone. | `MockedProvider` covering all 5 mutations, a `UserContext` decorator, a mock `WebSocketEventEmitter` dispatch harness exercised via `play` functions, and IntersectionObserver/ResizeObserver either present in the target browser or polyfilled. |
+| MessagesList | Thin wrapper around ChatMessageList; needs `useApolloClient` + a live `WebSocketEventEmitter` instance. User chose to postpone alongside ChatMessageList. | Same infra as ChatMessageList, applied to the wrapper's `loadMessages`/`isMessageInContext` callbacks. |
+| Thread | Same pattern as MessagesList, wrapping ChatMessageList for a thread's root message. User chose to postpone. | Same as MessagesList. |
+| ChatPage | Route-level page; aggregates `useWorkspaceChannelsList()` + `useWebsocket()` context and renders WorkspacesList/ChannelList/MessagesList/Thread together. User chose to postpone (recommended — low incremental value once children are covered). | All context decorators used above, composed together, plus a live-ish mock WebSocket provider and a real/mocked Apollo layer for the aggregated data flow. |
+| ClientLayout | Composes `WebSocketContextProvider` + `ChannelTypesListProvider` (uses `useSuspenseQuery`, needs a Suspense boundary) + `WorkspacesListProvider` + `WorkspaceChannelsListProvider`, and implicitly depends on an ambient `UserContext` from a layout that isn't present under `client/`. User chose to postpone. | The same 4 decorators plus a Suspense boundary and an outer `UserContext` decorator; realistically only demonstrates provider wiring, not real behavior. |
+
+## Caveats discovered while building this
+
+- **Hardcoded attachment URL**: `MessageAttachmentComponent.tsx` and `MessageEditorAttachment.tsx` both build their display URL via a hardcoded `http://localhost:9000/chatney/${urlPath}` rather than an env-driven base URL — a pre-existing smell in the app code, left as-is (not touched) per scope. Since that host is presumably a real local MinIO instance in normal app dev, Storybook doesn't run a competing server on port 9000; instead `src/test-utils/mocks/attachmentUrlHandlers.ts` (wired up via `msw` + `msw-storybook-addon` in `.storybook/preview.tsx`) intercepts requests to that specific host at the browser network layer and serves real sample bytes (fetched from CORS-permissive public hosts, matched by file extension), so image/gif/video/audio previews all render normally in stories. The `AudioAttachment` `FailedToLoad` story opts out of this handler (`parameters.msw.handlers = []`) so it can still demonstrate the real failure path.
+- **No dark-mode toolbar**: the app only supports dark mode via `prefers-color-scheme` media query, not a class-based toggle, so Storybook's preview has no manual dark/light switcher. Preview dark mode by changing your OS/browser color scheme.
+- **AudioAttachment decode-failure behavior**: confirmed the component degrades gracefully (falls back to an empty/flat waveform) rather than throwing when `fetch`/`decodeAudioData` fails — see the `FailedToLoad` story variant.
+- **`export` added to three context objects for testability**: `UserContext` (`src/contexts/UserContext.tsx`), `WorkspaceChannelsListContext` (`src/contexts/WorkspaceChannelsListContext.tsx`), and `ChannelTypesListContext` (`src/contexts/ChannelTypesListContext.tsx`) previously only exported their `Provider` component and `useX` hook, not the raw `Context` object. Each now also exports the `Context` itself so Storybook decorators can supply `Context.Provider value={...}` directly instead of using the real (side-effectful) provider components. `WorkspacesListContext` already exported its context and needed no change.
+- **`MessageEditorAttachment`'s "pending" (in-progress upload) variant is not covered** — see the Medium table above.
+- Test-runner/Chromatic/visual regression tooling is out of scope for this pass; `npx storybook add @storybook/addon-vitest` (or similar) can be layered in later if needed.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,10 +6,8 @@ import a11y from 'eslint-plugin-jsx-a11y';
 
 export default [
     { ignores: ['dist', 'node_modules', 'public'] },
-
     js.configs.recommended,
     ...tseslint.configs.recommended,
-
     {
         files: ['src/**/*.{ts,tsx}'],
         plugins: { react, 'react-hooks': reactHooks, 'jsx-a11y': a11y },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@storybook/addon-a11y": "^10.5.3",
+        "@storybook/addon-docs": "^10.5.3",
+        "@storybook/react-vite": "^10.5.3",
         "@tailwindcss/vite": "^4.0.15",
         "@types/apollo-upload-client": "^19.0.0",
         "@types/jest": "^30.0.0",
@@ -39,11 +42,21 @@
         "eslint-plugin-react-refresh": "^0.4.18",
         "globals": "^16.4.0",
         "jest": "^30.4.2",
+        "msw": "^2.15.0",
+        "msw-storybook-addon": "^2.0.7",
+        "storybook": "^10.5.3",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.44.1",
         "vite": "^6.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@apollo/client": {
       "version": "4.1.6",
@@ -230,9 +243,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -240,9 +253,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -274,13 +287,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.4"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -560,6 +573,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -595,14 +618,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1092,9 +1115,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1372,6 +1395,93 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1863,6 +1973,110 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1912,6 +2126,49 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1969,6 +2226,730 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3499,6 +4480,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
@@ -3834,6 +4851,242 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.3.tgz",
+      "integrity": "sha512-UJqvVfkTYFT+7MVTVzyMYxZoc2NNJQF+XE5fA8ABuMtQdBWYEgL2O3fjK0TR0F1JcXJZonj4trzyVNCVPjJi5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.3"
+      }
+    },
+    "node_modules/@storybook/addon-docs": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.5.3.tgz",
+      "integrity": "sha512-MI1VDMSMQk78YxjIdt7WlrVOiA3TzTP00lRed1LeXh0fCvA9jxz9YXJI2+XigsLaxCSuOAEf/l35/GTLDMHD8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "@storybook/csf-plugin": "10.5.3",
+        "@storybook/icons": "^2.0.2",
+        "@storybook/react-dom-shim": "10.5.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.3.tgz",
+      "integrity": "sha512-qX1jb1nbG1mWJrCn3YrDkpbii+KA1uxdVgENeNusD80RrWCwVG8ce+awjZxKuT8qjYyALSAPBvTHUqZ4C1b7Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.3",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.3.tgz",
+      "integrity": "sha512-mkPq6zru8fN5+46uC1cZEbKW2ws1hh9KvF4g4/Gu8pNbKnvqULPhk0/Bf0ZCtlr7zI7DvcFhyCy3dbvN+2n4Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.3",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.3.tgz",
+      "integrity": "sha512-d/CK78xgA7DDvqnxkqcYmiTjomE4ch2TWvk0O8/xHQWW6y0nMjKtsZbmUBfZ0QcdYdWq7dErzfbG7YAzxDi7Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.3",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.3",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.3.tgz",
+      "integrity": "sha512-eUWBsRRax5R3MDJVFs/CrFDF1bYS58AMB9tX02lLRuiZe6xy1cKh3CRFS+2xH571l0fNaXQ+7j69TOJ0fk2tmA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.3.tgz",
+      "integrity": "sha512-9cXaeU3+Kos4M3+Ezur2u/eBn3JIkED6ckxi7lhVQ6r2lK9NAGh5tfHSTQ/206KNSjvaHxZMAhPpxJP3/e2vfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.3",
+        "@storybook/react": "10.5.3",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.3",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -4111,10 +5364,126 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4133,6 +5502,13 @@
         "@types/extract-files": "*",
         "graphql": "14 - 16"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4178,6 +5554,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4245,6 +5646,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.18.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
@@ -4275,10 +5683,34 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4911,6 +6343,81 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@wry/caches": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
@@ -5245,6 +6752,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5502,6 +7032,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5593,6 +7139,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5618,6 +7181,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -5652,6 +7225,16 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -5793,12 +7376,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -5815,6 +7402,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -5917,6 +7511,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5932,6 +7536,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -5952,6 +7586,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
@@ -5968,6 +7615,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6008,6 +7665,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6057,6 +7721,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -6569,6 +8243,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6703,6 +8384,33 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -7112,9 +8820,9 @@
       "license": "MIT"
     },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -7251,6 +8959,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
+      "integrity": "sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7323,6 +9049,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -7501,6 +9237,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7579,6 +9331,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7604,6 +9375,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7800,6 +9578,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -8650,6 +10444,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -9009,6 +10810,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -9037,10 +10845,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9144,6 +10962,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9168,11 +10996,11 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -9196,6 +11024,90 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.15.0.tgz",
+      "integrity": "sha512-2wQAmKkQKxRuXvYJxVhPGG0wZNBQyD06oJvxqw90XqLvptdqxdlHrFUfEteKkpaNORX3Xzc+HtEl/q0nfmN2wQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.11",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-2.0.7.tgz",
+      "integrity": "sha512-TGmlxXy2TsaB6QcClVKRxqvay5f93xoLguHOihRFQ+gIEIyiyvcoQjkEeuOe7Y9qvddzGB1LyFomzPo9/EpnuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": "^2.0.0"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9417,6 +11329,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optimism": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
@@ -9447,6 +11378,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -9463,6 +11401,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
       }
     },
     "node_modules/p-limit": {
@@ -9606,6 +11613,23 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9930,6 +11954,73 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-docgen/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -10082,6 +12173,50 @@
         }
       }
     },
+    "node_modules/recast": {
+      "version": "0.23.12",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
+      "integrity": "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -10187,6 +12322,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -10238,6 +12380,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.52.3",
         "@rollup/rollup-win32-x64-msvc": "4.52.3",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -10583,6 +12738,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -10596,6 +12761,88 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/storybook": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.3.tgz",
+      "integrity": "sha512-c8Wumu5qz0N2fnzWBxcPzUsY+8BpKBKChNyl4BEh9qhMV6KW587gL8il8emRB+4Hay+zMjDHA7cIeTkl4FKYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -10871,6 +13118,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10924,6 +13184,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tailwindcss": {
@@ -11011,6 +13284,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -11059,6 +13339,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11079,10 +13389,23 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11090,6 +13413,16 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-jest": {
@@ -11169,6 +13502,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -11369,6 +13727,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
@@ -11405,6 +13792,16 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -11630,6 +14027,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -11867,6 +14271,44 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "test": "jest --passWithNoTests",
     "lint": "eslint .",
     "lint:soft": "eslint . --quiet",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@apollo/client": "^4.1.6",
@@ -29,6 +31,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@storybook/addon-a11y": "^10.5.3",
+    "@storybook/addon-docs": "^10.5.3",
+    "@storybook/react-vite": "^10.5.3",
     "@tailwindcss/vite": "^4.0.15",
     "@types/apollo-upload-client": "^19.0.0",
     "@types/jest": "^30.0.0",
@@ -44,9 +49,17 @@
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^16.4.0",
     "jest": "^30.4.2",
+    "msw": "^2.15.0",
+    "msw-storybook-addon": "^2.0.7",
+    "storybook": "^10.5.3",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.44.1",
     "vite": "^6.1.0"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,361 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = isEventStreamResponse ? null : response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
+          },
+        },
+      },
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,6 +13,18 @@
       "skillPath": "skills/graphql-operations/SKILL.md",
       "computedHash": "d0532171706cbba72112a6f3ffdc49d5d15b22fdd092de7324099e767bf1cbf1"
     },
+    "storybook-setup": {
+      "source": "patricio0312rev/skills",
+      "sourceType": "github",
+      "skillPath": "foundation/storybook-setup/SKILL.md",
+      "computedHash": "fafd159d7a60ca872eddd2d5561cfedefa509cecfaeb87ad1a24fa3dc64afc59"
+    },
+    "storybook-stories": {
+      "source": "pedronauck/skills",
+      "sourceType": "github",
+      "skillPath": "skills/mine/storybook-stories/SKILL.md",
+      "computedHash": "9978ee12cc47c35da310ebb95edceff6e2f5fcc5bea3b2ba32d6552c0da71ba2"
+    },
     "tailwindcss": {
       "source": "hairyf/skills",
       "sourceType": "github",

--- a/src/contexts/ChannelTypesListContext.tsx
+++ b/src/contexts/ChannelTypesListContext.tsx
@@ -9,7 +9,7 @@ interface ChannelTypesListContextValue {
     refetch: () => void;
 }
 
-const ChannelTypesListContext = createContext<ChannelTypesListContextValue | null>(null);
+export const ChannelTypesListContext = createContext<ChannelTypesListContextValue | null>(null);
 
 export function ChannelTypesListProvider({ children }: PropsWithChildren) {
     const { data, refetch } = useSuspenseQuery(GET_CHANNEL_TYPES_QUERY, {

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -5,7 +5,7 @@ import { loginPageUrl, userAuthId, userAuthTokenName } from '@/infra/consts';
 import { Workspace } from '@/types/workspaces';
 import { UserId } from '@/types/users';
 
-const UserContext = createContext<UserContextData | null>(null);
+export const UserContext = createContext<UserContextData | null>(null);
 
 export type UserContextData = {
     user: {

--- a/src/contexts/WorkspaceChannelsListContext.tsx
+++ b/src/contexts/WorkspaceChannelsListContext.tsx
@@ -12,7 +12,7 @@ interface WorkspaceChannelsListContextValue {
     setActiveChannel: (ch: Channel) => void
 }
 
-const WorkspaceChannelsListContext = createContext<WorkspaceChannelsListContextValue>(null as unknown as WorkspaceChannelsListContextValue);
+export const WorkspaceChannelsListContext = createContext<WorkspaceChannelsListContextValue>(null as unknown as WorkspaceChannelsListContextValue);
 
 export function WorkspaceChannelsListProvider({ children }: PropsWithChildren) {
     const { activeWorkspaceId } = useContext(WorkspacesListContext);

--- a/src/helpers/formatTimestamp.ts
+++ b/src/helpers/formatTimestamp.ts
@@ -1,5 +1,7 @@
 import { DateTime } from 'luxon';
 
 export function formatTimestamp(timestamp: Date): string {
-    return DateTime.fromJSDate(timestamp).toFormat('dd.MM.yyyy HH:mm');
+    const dateTime = DateTime.fromJSDate(timestamp);
+    const isWithinLastDay = dateTime > DateTime.now().minus({ hours: 24 });
+    return dateTime.toFormat(isWithinLastDay ? 'HH:mm' : 'dd.MM.yyyy HH:mm');
 }

--- a/src/index.css
+++ b/src/index.css
@@ -26,17 +26,17 @@
 
 @layer theme {
     :root {
-        --color-main: #3e939f;
+        --color-main: var(--color-indigo-400);
         --text-color: var(--color-zinc-800);
         --page-bg-color: var(--color-zinc-200);
 
-        --main-menu-bg-color: var(--color-amber-800);
-        --main-menu-bg-color-hover: var(--color-amber-600);
+        --main-menu-bg-color: var(--color-indigo-900);
+        --main-menu-bg-color-hover: var(--color-indigo-600);
         --main-menu-text-color: var(--color-white);
 
-        --button-bg-color: var(--color-amber-600);
+        --button-bg-color: var(--color-indigo-500);
         --button-text-color: var(--color-white);
-        --button-bg-color-hover: var(--color-amber-700);
+        --button-bg-color-hover: var(--color-indigo-600);
     }
 
     @media (prefers-color-scheme: dark) {
@@ -49,13 +49,13 @@
 
 @layer base {
     h1 {
-        @apply py-4 text-amber-500 font-bold text-4xl;
+        @apply py-4 text-indigo-400 font-bold text-4xl;
     }
     h2 {
-        @apply py-4 text-amber-500 font-bold text-3xl;
+        @apply py-4 text-indigo-400 font-bold text-3xl;
     }
     h3 {
-        @apply py-4 text-amber-500 font-bold text-2xl;
+        @apply py-4 text-indigo-400 font-bold text-2xl;
     }
 }
 

--- a/src/pages/client/Chat/AudioAttachment/AudioAttachment.stories.tsx
+++ b/src/pages/client/Chat/AudioAttachment/AudioAttachment.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AudioAttachment } from './AudioAttachment';
+import { mockAudioAttachment, samplePlaceholderAudioUrl } from '@/test-utils/fixtures/attachments';
+
+/**
+ * AudioAttachment fetches `attachmentUrl` and decodes it via the Web Audio API to draw a
+ * waveform. It degrades gracefully (falls back to an empty/flat waveform) if the fetch or
+ * decode fails, so this still renders sensibly without network access — see
+ * STORYBOOK_COVERAGE.md caveats.
+ */
+const meta: Meta<typeof AudioAttachment> = {
+    title: 'pages/client/Chat/AudioAttachment',
+    component: AudioAttachment,
+};
+export default meta;
+
+type Story = StoryObj<typeof AudioAttachment>;
+
+/** An audio message with a real sample clip, so the waveform decodes successfully. */
+export const Default: Story = {
+    args: {
+        attachment: mockAudioAttachment,
+        attachmentUrl: samplePlaceholderAudioUrl,
+    },
+};
+
+/** A broken/unreachable URL — the waveform falls back to its empty state instead of throwing. */
+export const FailedToLoad: Story = {
+    // Opt out of the global attachmentUrlHandlers mock (see attachmentUrlHandlers.ts) so this URL genuinely fails to load.
+    parameters: {
+        msw: { handlers: [] },
+    },
+    args: {
+        attachment: mockAudioAttachment,
+        attachmentUrl: 'http://localhost:9000/chatney/does-not-exist.mp3',
+    },
+};

--- a/src/pages/client/Chat/ChannelsList/ChannelsList.stories.tsx
+++ b/src/pages/client/Chat/ChannelsList/ChannelsList.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { ChannelList } from './ChannelsList';
+import { withWorkspacesList } from '@/test-utils/decorators/withWorkspacesList';
+import { mockChannel1, mockChannelsList } from '@/test-utils/fixtures/channels';
+
+/** Opening "+ Create channel" mounts CreateChannelModal, which needs its own GraphQL/context mocks — see STORYBOOK_COVERAGE.md. */
+const meta: Meta<typeof ChannelList> = {
+    title: 'pages/client/Chat/ChannelsList',
+    component: ChannelList,
+    decorators: [withWorkspacesList()],
+};
+export default meta;
+
+type Story = StoryObj<typeof ChannelList>;
+
+/** A channel list with one active channel selected. */
+export const Default: Story = {
+    args: {
+        channels: mockChannelsList,
+        activeChannel: mockChannel1,
+        setActiveChannel: action('setActiveChannel'),
+        refetch: action('refetch'),
+    },
+};
+
+/** No channels yet in this workspace. */
+export const Empty: Story = {
+    args: {
+        channels: [],
+        activeChannel: null,
+        setActiveChannel: action('setActiveChannel'),
+        refetch: action('refetch'),
+    },
+};

--- a/src/pages/client/Chat/ChatMessageList/ChatMessageList.tsx
+++ b/src/pages/client/Chat/ChatMessageList/ChatMessageList.tsx
@@ -354,7 +354,7 @@ export const ChatMessageList = ({
                     onSaveEdit={handleSaveEdit}
                     onCancelEdit={() => setEditingMessage(null)}
                     editingMessage={editingMessage}
-                    replyToPreview={replyingTo?.content ?? null}
+                    replyToMessage={replyingTo}
                     onClearReply={handleClearReply}
                 />
             </div>

--- a/src/pages/client/Chat/CreateChannelModal/CreateChannelModal.stories.tsx
+++ b/src/pages/client/Chat/CreateChannelModal/CreateChannelModal.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { gql } from '@apollo/client';
+import { MockedProvider } from '@apollo/client/testing/react';
+import { action } from 'storybook/actions';
+import { CreateChannelModal } from './CreateChannelModal';
+import { withWorkspacesList } from '@/test-utils/decorators/withWorkspacesList';
+import { withChannelTypesList } from '@/test-utils/decorators/withChannelTypesList';
+
+const ADD_CHANNEL_MUTATION = gql`
+    mutation AddChannel($name: String!, $channelTypeId: Int!, $workspaceId: Int!) {
+        channels {
+            addChannel(channelDto: { name: $name, channelTypeId: $channelTypeId, workspaceId: $workspaceId }) {
+                id
+                name
+                channelTypeId
+                workspaceId
+                createdAt
+                updatedAt
+            }
+        }
+    }
+`;
+
+const mocks = [
+    {
+        request: { query: ADD_CHANNEL_MUTATION, variables: { name: 'announcements', channelTypeId: 1, workspaceId: 1 } },
+        result: {
+            data: {
+                channels: {
+                    addChannel: {
+                        id: 3,
+                        name: 'announcements',
+                        channelTypeId: 1,
+                        workspaceId: 1,
+                        createdAt: '2026-01-15T10:00:00Z',
+                        updatedAt: '2026-01-15T10:00:00Z',
+                    },
+                },
+            },
+        },
+    },
+];
+
+/** Needs both WorkspacesListContext (for the active workspace) and ChannelTypesListContext (for the type dropdown) plus a live Apollo mutation on submit — composed here via decorators + MockedProvider. */
+const meta: Meta<typeof CreateChannelModal> = {
+    title: 'pages/client/Chat/CreateChannelModal',
+    component: CreateChannelModal,
+    decorators: [
+        withWorkspacesList(),
+        withChannelTypesList(),
+        (Story) => (
+            <MockedProvider mocks={mocks}>
+                <Story />
+            </MockedProvider>
+        ),
+    ],
+};
+export default meta;
+
+type Story = StoryObj<typeof CreateChannelModal>;
+
+/** The create-channel dialog, showing the channel-type dropdown populated from context. */
+export const Default: Story = {
+    args: {
+        onClose: action('onClose'),
+        onChannelCreated: action('onChannelCreated'),
+    },
+};

--- a/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.module.css
+++ b/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.module.css
@@ -1,7 +1,12 @@
 @reference "tailwindcss";
 
+.anchor {
+    @apply absolute inset-0 pointer-events-none;
+}
+
 .container {
-    @apply absolute bottom-full left-0 z-10 mb-2 flex w-full max-w-md flex-col overflow-hidden rounded-lg border border-gray-600 bg-gray-900 py-1 shadow-lg;
+    @apply z-10 flex max-w-md flex-col overflow-hidden rounded-lg border border-gray-600 bg-gray-900 py-1 shadow-lg;
+    width: var(--radix-popover-trigger-width);
 }
 
 .suggestion {

--- a/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.stories.tsx
+++ b/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.stories.tsx
@@ -1,0 +1,56 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { EmojiSuggestionsPopup } from './EmojiSuggestionsPopup';
+
+/** Mimics the real anchor: a positioned, fixed-width container (like MessageInput's `.inputWrapper`) with a given amount of room above/below it. */
+const withAnchorRoom = (paddingTop: number, paddingBottom: number): Decorator => (Story) => (
+    <div style={{ paddingTop, paddingBottom }}>
+        <div style={{ position: 'relative', width: 320 }}>
+            <Story />
+        </div>
+    </div>
+);
+
+const meta: Meta<typeof EmojiSuggestionsPopup> = {
+    title: 'pages/client/Chat/EmojiSuggestionsPopup',
+    component: EmojiSuggestionsPopup,
+};
+export default meta;
+
+type Story = StoryObj<typeof EmojiSuggestionsPopup>;
+
+/** Suggestions matching a partial `:sm` query, with plenty of room above the anchor — the popup renders above it, as in the real chat composer. */
+export const Default: Story = {
+    decorators: [withAnchorRoom(320, 0)],
+    args: {
+        query: 'sm',
+        onSelect: action('onSelect'),
+    },
+};
+
+/** Same query, but with no room above the anchor — Radix's collision detection flips the popup to render below instead of clipping. */
+export const FlipsBelowWhenNoRoomAbove: Story = {
+    decorators: [withAnchorRoom(0, 320)],
+    args: {
+        query: 'sm',
+        onSelect: action('onSelect'),
+    },
+};
+
+/** No query typed yet — the popup renders nothing. */
+export const NoQuery: Story = {
+    decorators: [withAnchorRoom(200, 0)],
+    args: {
+        query: null,
+        onSelect: action('onSelect'),
+    },
+};
+
+/** A query with no matching emoji also renders nothing. */
+export const NoMatches: Story = {
+    decorators: [withAnchorRoom(200, 0)],
+    args: {
+        query: 'zzzzz',
+        onSelect: action('onSelect'),
+    },
+};

--- a/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.tsx
+++ b/src/pages/client/Chat/EmojiSuggestionsPopup/EmojiSuggestionsPopup.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEvent, Ref, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import clsx from 'clsx';
+import { Popover } from 'radix-ui';
 
 import { ALL_REACTION_CODES, REACTION_DETAILS } from '@/pages/client/Chat/emojis';
 
@@ -46,7 +47,7 @@ const searchEmojis = (query: string): EmojiSuggestion[] => {
     return [...prefixMatches.sort(byLabel), ...substringMatches.sort(byLabel)].slice(0, MAX_EMOJI_SUGGESTIONS);
 };
 
-// expects a positioned ancestor: renders anchored above it
+// anchored where it's rendered; flips below its anchor via Radix collision detection if there's no room above
 export function EmojiSuggestionsPopup({ query, onSelect, ref }: Props) {
     const suggestions = useMemo(() => (query ? searchEmojis(query) : []), [query]);
     const [highlighted, setHighlighted] = useState(0);
@@ -78,31 +79,47 @@ export function EmojiSuggestionsPopup({ query, onSelect, ref }: Props) {
         },
     }));
 
-    if (suggestions.length === 0) {
-        return null;
-    }
+    const isOpen = suggestions.length > 0;
 
     return (
-        <div className={styles.container} role="listbox" aria-label="Emoji suggestions">
-            {suggestions.map((suggestion, index) => (
-                <button
-                    type="button"
-                    key={suggestion.code}
-                    role="option"
-                    aria-selected={index === activeIndex}
-                    className={clsx(styles.suggestion, index === activeIndex && styles.suggestionActive)}
-                    onMouseDown={(e) => {
-                        // keep focus in the text input while picking with the mouse
-                        e.preventDefault();
-                        onSelect(suggestion);
-                    }}
-                    onMouseEnter={() => setHighlighted(index)}
+        <Popover.Root open={isOpen}>
+            {/* Zero-size marker kept at the popup's original DOM position; Radix positions the portalled content relative to it and flips side/align to avoid viewport collisions. */}
+            <Popover.Anchor asChild>
+                <span className={styles.anchor} />
+            </Popover.Anchor>
+            <Popover.Portal>
+                <Popover.Content
+                    role="listbox"
+                    aria-label="Emoji suggestions"
+                    className={styles.container}
+                    side="top"
+                    align="start"
+                    sideOffset={8}
+                    collisionPadding={8}
+                    onOpenAutoFocus={(e) => e.preventDefault()}
+                    onCloseAutoFocus={(e) => e.preventDefault()}
                 >
-                    <span className={styles.emoji}>{suggestion.emoji}</span>
-                    <span className={styles.label}>{suggestion.label}</span>
-                    <span className={styles.code}>:{suggestion.code}:</span>
-                </button>
-            ))}
-        </div>
+                    {suggestions.map((suggestion, index) => (
+                        <button
+                            type="button"
+                            key={suggestion.code}
+                            role="option"
+                            aria-selected={index === activeIndex}
+                            className={clsx(styles.suggestion, index === activeIndex && styles.suggestionActive)}
+                            onMouseDown={(e) => {
+                                // keep focus in the text input while picking with the mouse
+                                e.preventDefault();
+                                onSelect(suggestion);
+                            }}
+                            onMouseEnter={() => setHighlighted(index)}
+                        >
+                            <span className={styles.emoji}>{suggestion.emoji}</span>
+                            <span className={styles.label}>{suggestion.label}</span>
+                            <span className={styles.code}>:{suggestion.code}:</span>
+                        </button>
+                    ))}
+                </Popover.Content>
+            </Popover.Portal>
+        </Popover.Root>
     );
 }

--- a/src/pages/client/Chat/FullscreenPreview/FullscreenPreview.stories.tsx
+++ b/src/pages/client/Chat/FullscreenPreview/FullscreenPreview.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { FullscreenPreview } from './FullscreenPreview';
+import { samplePlaceholderImageUrl, samplePlaceholderVideoUrl } from '@/test-utils/fixtures/attachments';
+
+const meta: Meta<typeof FullscreenPreview> = {
+    title: 'pages/client/Chat/FullscreenPreview',
+    component: FullscreenPreview,
+};
+export default meta;
+
+type Story = StoryObj<typeof FullscreenPreview>;
+
+/** Fullscreen overlay showing an image. */
+export const Image: Story = {
+    args: {
+        attachmentType: 'image',
+        attachmentUrl: samplePlaceholderImageUrl,
+        fileName: 'sunset.jpg',
+        onClose: action('onClose'),
+    },
+};
+
+/** Fullscreen overlay showing a playable video. */
+export const Video: Story = {
+    args: {
+        attachmentType: 'video',
+        attachmentUrl: samplePlaceholderVideoUrl,
+        fileName: 'demo.mp4',
+        onClose: action('onClose'),
+    },
+};

--- a/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.module.css
+++ b/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.module.css
@@ -1,29 +1,38 @@
 @reference "tailwindcss";
 
 .mediaButton {
-    @apply block max-w-full rounded-lg border-0 bg-transparent p-0 text-left;
+    @apply block max-w-full rounded-xl border-0 bg-transparent p-0 text-left;
 }
 
 .image {
-    @apply max-h-80 max-w-full cursor-zoom-in rounded-lg object-contain;
+    @apply max-h-80 max-w-full cursor-zoom-in rounded-xl object-contain;
 }
 
 .video {
-    @apply max-h-80 max-w-full cursor-zoom-in rounded-lg;
+    @apply max-h-80 max-w-full cursor-zoom-in rounded-xl;
 }
 
 .binary {
-    @apply inline-flex max-w-full items-center gap-2 rounded border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-gray-200 hover:border-gray-500 hover:bg-gray-700;
+    @apply inline-flex max-w-full items-center gap-3 rounded-xl border border-[#28345a] bg-[#1b2440] px-3 py-2.5
+        hover:border-[#3a4a7d] hover:bg-[#212c4e] transition-colors;
+}
+
+.binaryIconTile {
+    @apply flex size-10 shrink-0 items-center justify-center rounded-lg bg-[#232e52];
 }
 
 .binaryIcon {
-    @apply shrink-0 text-gray-300;
+    @apply text-indigo-300;
+}
+
+.binaryInfo {
+    @apply flex min-w-0 flex-col;
 }
 
 .binaryName {
-    @apply min-w-0 break-all;
+    @apply min-w-0 break-all text-sm font-semibold text-white;
 }
 
 .binarySize {
-    @apply shrink-0 text-xs text-gray-400;
+    @apply text-xs text-[#8b93b0];
 }

--- a/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.stories.tsx
+++ b/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageAttachmentComponent } from './MessageAttachmentComponent';
+import {
+    mockAudioAttachment,
+    mockBinaryAttachment,
+    mockGifAttachment,
+    mockImageAttachment,
+    mockVideoAttachment,
+} from '@/test-utils/fixtures/attachments';
+
+/**
+ * The component builds its display URL from `attachment.urlPath` via a hardcoded
+ * `http://localhost:9000/chatney/...` base (see STORYBOOK_COVERAGE.md caveats). Storybook's
+ * MSW handler (src/test-utils/mocks/attachmentUrlHandlers.ts) intercepts that specific host and
+ * serves real sample bytes matched by file extension, so previews render normally here.
+ */
+const meta: Meta<typeof MessageAttachmentComponent> = {
+    title: 'pages/client/Chat/MessageAttachmentComponent',
+    component: MessageAttachmentComponent,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageAttachmentComponent>;
+
+/** An image attachment, rendered as a clickable thumbnail. */
+export const Image: Story = {
+    args: {
+        attachment: mockImageAttachment,
+    },
+};
+
+/** An animated GIF attachment. */
+export const Gif: Story = {
+    args: {
+        attachment: mockGifAttachment,
+    },
+};
+
+/** A video attachment. */
+export const Video: Story = {
+    args: {
+        attachment: mockVideoAttachment,
+    },
+};
+
+/** An audio attachment, rendered with a waveform player. */
+export const Audio: Story = {
+    args: {
+        attachment: mockAudioAttachment,
+    },
+};
+
+/** A generic binary file, rendered as a download link with a file-type icon. */
+export const Binary: Story = {
+    args: {
+        attachment: mockBinaryAttachment,
+    },
+};

--- a/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.tsx
+++ b/src/pages/client/Chat/MessageAttachmentComponent/MessageAttachmentComponent.tsx
@@ -82,9 +82,18 @@ export const MessageAttachmentComponent = ({ attachment }: Props) => {
                     target="_blank"
                     rel="noopener noreferrer"
                 >
-                    {getFileIcon(contentAttachmentType, { className: styles.binaryIcon, size: 18 })}
-                    <span className={styles.binaryName}>{attachment.originalFileName}</span>
-                    <span className={styles.binarySize}>{formatFileSize(attachment.size)}</span>
+                    <span className={styles.binaryIconTile}>
+                        {getFileIcon(contentAttachmentType, { className: styles.binaryIcon, size: 20 })}
+                    </span>
+                    <span className={styles.binaryInfo}>
+                        <span className={styles.binaryName}>{attachment.originalFileName}</span>
+                        <span className={styles.binarySize}>
+                            {formatFileSize(attachment.size)}
+                            {attachment.originalFileName.includes('.') && (
+                                <> • {attachment.originalFileName.split('.').pop()?.toUpperCase()}</>
+                            )}
+                        </span>
+                    </span>
                 </a>
             );
     }

--- a/src/pages/client/Chat/MessageAttachments/MessageAttachments.stories.tsx
+++ b/src/pages/client/Chat/MessageAttachments/MessageAttachments.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageAttachments } from './MessageAttachments';
+import { mockBinaryAttachment, mockImageAttachment } from '@/test-utils/fixtures/attachments';
+
+const meta: Meta<typeof MessageAttachments> = {
+    title: 'pages/client/Chat/MessageAttachments',
+    component: MessageAttachments,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageAttachments>;
+
+/** A single image attachment. */
+export const Default: Story = {
+    args: {
+        attachments: [mockImageAttachment],
+    },
+};
+
+/** Multiple attachments of different kinds rendered together. */
+export const Multiple: Story = {
+    args: {
+        attachments: [mockImageAttachment, mockBinaryAttachment],
+    },
+};
+
+/** No attachments — renders nothing. */
+export const Empty: Story = {
+    args: {
+        attachments: [],
+    },
+};

--- a/src/pages/client/Chat/MessageComponent/MessageComponent.module.css
+++ b/src/pages/client/Chat/MessageComponent/MessageComponent.module.css
@@ -1,52 +1,55 @@
 @reference "tailwindcss";
 
 .container {
-    --bg-color-1: #366aaa;
-    --bg-color-2: #2a496c;
-    --bg-color-3: #2a496c;
-    @apply box-border rounded-lg p-2 flex items-start space-x-4 max-w-[30em];
-    background-image: linear-gradient(to bottom, var(--bg-color-1) 0%, var(--bg-color-2) 60%, var(--bg-color-3) 100%);
-    background-attachment: fixed;
+    @apply box-border rounded-2xl p-4 flex items-start gap-3 max-w-[36em]
+        bg-[#151d33] border border-[#232e4d]
+        shadow-[0_8px_24px_rgba(2,8,23,0.35)];
 }
 
-.innerContainer {}
+.innerContainer {
+    @apply flex-1 min-w-0;
+}
 
 .header {
-    @apply flex items-center space-x-2 relative;
+    @apply flex items-center gap-2 relative;
+}
+
+.userName {
+    @apply font-semibold text-indigo-100;
 }
 
 .timestamp {
-    @apply text-xs text-yellow-500;
+    @apply ml-auto text-xs text-[#7d87a8];
 }
 
 .replyButton {
-    @apply cursor-pointer text-gray-400 hover:text-indigo-400;
+    @apply w-4 h-4 cursor-pointer text-[#5f6a8c] hover:text-indigo-300;
 }
 
 .editButton {
-    @apply cursor-pointer text-gray-400 hover:text-yellow-400 w-4 h-4;
+    @apply w-4 h-4 cursor-pointer text-[#5f6a8c] hover:text-indigo-300;
 }
 
 .editedLabel {
-    @apply text-xs text-gray-500 italic;
+    @apply text-xs text-[#7d87a8] italic;
 }
 
 .deleteButton {
-    @apply cursor-pointer text-red-500;
+    @apply w-4 h-4 cursor-pointer text-[#5f6a8c] hover:text-red-400;
 }
 
 .replyQuote {
-    @apply mt-1 px-2 py-1 text-xs text-gray-400 border-l-2 border-indigo-400 bg-black/20 rounded-sm break-all;
+    @apply mt-2 px-3 py-1.5 text-xs text-[#9aa3c0] border-l-2 border-indigo-400 bg-[#0f1526] rounded-md [overflow-wrap:anywhere];
     font-family: Inter, system-ui, Avenir, Helvetica, Arial, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Twemoji Mozilla', sans-serif;
 }
 
 .textContent {
-    @apply text-gray-200 break-all py-2;
+    @apply text-[#dbe1f4] leading-relaxed py-2 whitespace-pre-wrap [overflow-wrap:anywhere];
     font-family: Inter, system-ui, Avenir, Helvetica, Arial, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Twemoji Mozilla', sans-serif;
 }
 
 .isMine {
-    @apply self-end;
+    @apply self-end bg-[#1a2340] border-[#2f3c66];
 }
 
 .avatar {

--- a/src/pages/client/Chat/MessageComponent/MessageComponent.stories.tsx
+++ b/src/pages/client/Chat/MessageComponent/MessageComponent.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageComponent } from './MessageComponent';
+import {
+    mockEditedMessage,
+    mockMessageWithAttachment,
+    mockMessageWithReactions,
+    mockOwnMessage,
+    mockPlainMessage,
+    mockReplyMessage,
+    mockReplyToMessage,
+    mockThreadedMessage,
+} from '@/test-utils/fixtures/messages';
+import { mockUserId1 } from '@/test-utils/fixtures/users';
+
+const meta: Meta<typeof MessageComponent> = {
+    title: 'pages/client/Chat/MessageComponent',
+    component: MessageComponent,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageComponent>;
+
+const callbacks = {
+    onDelete: action('onDelete'),
+    onReply: action('onReply'),
+    onEdit: action('onEdit'),
+    onAddReaction: action('onAddReaction'),
+    onDeleteReaction: action('onDeleteReaction'),
+    onOpenThread: action('onOpenThread'),
+};
+
+/** A plain text message from another user. */
+export const Default: Story = {
+    args: {
+        message: mockPlainMessage,
+        currentUserId: mockUserId1,
+        ...callbacks,
+    },
+};
+
+/** A message sent by the current user, styled as "mine". */
+export const OwnMessage: Story = {
+    args: {
+        message: mockOwnMessage,
+        currentUserId: mockOwnMessage.userId,
+        ...callbacks,
+    },
+};
+
+/** A message carrying an image attachment. */
+export const WithAttachment: Story = {
+    args: {
+        message: mockMessageWithAttachment,
+        currentUserId: mockUserId1,
+        ...callbacks,
+    },
+};
+
+/** A message with existing emoji reactions, one of which belongs to the current user. */
+export const WithReactions: Story = {
+    args: {
+        message: mockMessageWithReactions,
+        currentUserId: mockUserId1,
+        ...callbacks,
+    },
+};
+
+/** A message that has been edited after being sent. */
+export const Edited: Story = {
+    args: {
+        message: mockEditedMessage,
+        currentUserId: mockUserId1,
+        ...callbacks,
+    },
+};
+
+/** A thread root message showing the reply count button. */
+export const WithThread: Story = {
+    args: {
+        message: mockThreadedMessage,
+        currentUserId: mockUserId1,
+        ...callbacks,
+    },
+};
+
+/** A message shown as a reply, quoting the message it replies to. */
+export const AsReply: Story = {
+    args: {
+        message: mockReplyMessage,
+        currentUserId: mockUserId1,
+        replyRef: mockReplyToMessage,
+        ...callbacks,
+    },
+};

--- a/src/pages/client/Chat/MessageComponent/MessageComponent.tsx
+++ b/src/pages/client/Chat/MessageComponent/MessageComponent.tsx
@@ -45,12 +45,15 @@ export const MessageComponent = ({ message, currentUserId, replyRef, onDelete, o
             <div className={styles.innerContainer}>
                 <div className={styles.header}>
                     {!isMine && (
-                        <span className="font-medium">
+                        <span className={styles.userName}>
                             {message.user?.name ?? message.userId}
                         </span>
                     )}
                     <span className={styles.timestamp}>
                         {formatTimestamp(new Date(message.updatedAt))}
+                        {new Date(message.updatedAt).getTime() !== new Date(message.createdAt).getTime() && (
+                            <span className={styles.editedLabel}> (edited)</span>
+                        )}
                     </span>
                     <CornerUpLeft
                         className={styles.replyButton}
@@ -74,9 +77,6 @@ export const MessageComponent = ({ message, currentUserId, replyRef, onDelete, o
                 )}
                 <div className={styles.textContent}>
                     {message.content}
-                    {new Date(message.updatedAt).getTime() !== new Date(message.createdAt).getTime() && (
-                        <span className={styles.editedLabel}> (edited)</span>
-                    )}
                 </div>
                 <MessageAttachments attachments={message.attachments}/>
                 <MessageUrlPreviewsComponent urlPreviews={message.urlPreviews}/>

--- a/src/pages/client/Chat/MessageEditorAttachment/MessageEditorAttachment.stories.tsx
+++ b/src/pages/client/Chat/MessageEditorAttachment/MessageEditorAttachment.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageEditorAttachment } from './MessageEditorAttachment';
+import { mockAudioAttachment, mockImageAttachment } from '@/test-utils/fixtures/attachments';
+
+/**
+ * Only the "uploaded" prop variant is covered here. The "pending" variant (new file being
+ * uploaded) calls the real `uploadFileWithProgress` via raw XHR in a `useEffect` on mount —
+ * without a module-mocking mechanism (no addon-vitest in this install, see
+ * STORYBOOK_COVERAGE.md) that XHR can't be intercepted, so it was left out rather than shipping
+ * a story that always errors against a real endpoint.
+ */
+const meta: Meta<typeof MessageEditorAttachment> = {
+    title: 'pages/client/Chat/MessageEditorAttachment',
+    component: MessageEditorAttachment,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageEditorAttachment>;
+
+/** An already-uploaded image attachment shown in the composer. */
+export const UploadedImage: Story = {
+    args: {
+        attachment: mockImageAttachment,
+        onDelete: action('onDelete'),
+    },
+};
+
+/** An already-uploaded audio attachment shown in the composer. */
+export const UploadedAudio: Story = {
+    args: {
+        attachment: mockAudioAttachment,
+        onDelete: action('onDelete'),
+    },
+};

--- a/src/pages/client/Chat/MessageInput/MessageInput.module.css
+++ b/src/pages/client/Chat/MessageInput/MessageInput.module.css
@@ -1,18 +1,24 @@
 @reference "tailwindcss";
 
 .container {
-    @apply w-full border-t border-gray-700 p-3 flex flex-col items-center bg-gray-800;
+    @apply w-full p-3 flex flex-col items-center bg-transparent;
 }
 
 .sendForm {
-    @apply w-full flex flex-row items-center;
+    @apply w-full flex flex-row items-end gap-1 rounded-2xl border border-[#232e4d] bg-[#141c33] px-3 py-2
+        shadow-[0_8px_24px_rgba(2,8,23,0.35)]
+        focus-within:border-[#3a4a7d];
 }
 
 .sendButton {
-    @apply ml-2 px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-500 cursor-pointer;
+    @apply ml-2 p-2.5 bg-indigo-500 text-white rounded-xl hover:bg-indigo-400 cursor-pointer;
+
+    & svg {
+        @apply w-5 h-5;
+    }
 
     &:disabled {
-        @apply bg-gray-500 text-gray-700 cursor-not-allowed;
+        @apply bg-[#232e4d] text-[#5f6a8c] cursor-not-allowed;
     }
 }
 
@@ -22,15 +28,15 @@
 }
 
 .voiceRecordIcon {
-    @apply mr-4 text-amber-500 cursor-pointer;
+    @apply mx-1.5 mb-2.5 w-5 h-5 text-[#7d87a8] cursor-pointer hover:text-indigo-300;
 }
 
 .videoRecordIcon {
-    @apply mr-4 text-amber-500 cursor-pointer;
+    @apply mx-1.5 mb-2.5 w-5 h-5 text-[#7d87a8] cursor-pointer hover:text-indigo-300;
 }
 
 .fileAttachmentIcon {
-    @apply mr-4 text-amber-500 cursor-pointer;
+    @apply mx-1.5 mb-2.5 w-5 h-5 text-[#7d87a8] cursor-pointer hover:text-indigo-300;
 }
 
 .fileDropArea {
@@ -50,11 +56,31 @@
 }
 
 .replyPreview {
-    @apply flex items-center justify-between w-full px-3 py-1.5 mb-1 rounded bg-gray-700 border-l-2 border-indigo-500 text-sm text-gray-300;
+    @apply flex items-center gap-3 w-full mb-2;
+}
+
+.replyPreviewAvatar {
+    @apply w-12 h-12 shrink-0 rounded-full object-cover;
+}
+
+.replyPreviewQuote {
+    @apply flex-1 min-w-0 rounded-lg rounded-l-sm border-l-2 border-indigo-400 bg-[#182036] px-4 py-2;
+}
+
+.replyPreviewHeader {
+    @apply flex items-baseline gap-1.5;
+}
+
+.replyPreviewAuthor {
+    @apply text-xs font-bold uppercase tracking-wider text-indigo-300;
+}
+
+.replyPreviewTime {
+    @apply text-xs text-[#7d87a8];
 }
 
 .replyPreviewText {
-    @apply truncate;
+    @apply mt-0.5 truncate text-sm italic text-[#aeb6d4];
     font-family: Inter, system-ui, Avenir, Helvetica, Arial, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Twemoji Mozilla', sans-serif;
 }
 

--- a/src/pages/client/Chat/MessageInput/MessageInput.stories.tsx
+++ b/src/pages/client/Chat/MessageInput/MessageInput.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageInput } from './MessageInput';
+import { mockImageAttachment } from '@/test-utils/fixtures/attachments';
+import { mockOwnMessage } from '@/test-utils/fixtures/messages';
+
+/**
+ * Only baseline states are covered (empty, editing, replying). MessageInput's voice/video
+ * recorder buttons and drag-and-drop upload flow trigger real `getUserMedia`/`MediaRecorder`/XHR
+ * side effects in its children and aren't exercised here — see STORYBOOK_COVERAGE.md.
+ */
+const meta: Meta<typeof MessageInput> = {
+    title: 'pages/client/Chat/MessageInput',
+    component: MessageInput,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageInput>;
+
+/** An empty composer, ready for a new message. */
+export const Default: Story = {
+    args: {
+        onSend: action('onSend'),
+    },
+};
+
+/** Editing an existing message with an attachment already attached. */
+export const Editing: Story = {
+    args: {
+        editingMessage: { id: 1, content: 'Original text before the edit', attachments: [mockImageAttachment] },
+        onSend: action('onSend'),
+        onSaveEdit: action('onSaveEdit'),
+        onCancelEdit: action('onCancelEdit'),
+    },
+};
+
+/** Composing a reply, with the quoted message shown above the input. */
+export const Replying: Story = {
+    args: {
+        replyToMessage: mockOwnMessage,
+        onSend: action('onSend'),
+        onClearReply: action('onClearReply'),
+    },
+};
+
+/**
+ * Editing a message while a reply is also pending. In real usage (ChatMessageList.tsx),
+ * `editingMessage` and `replyToMessage` are independent pieces of state — e.g. you start
+ * replying to one message, then click edit on a different message before sending. The component
+ * gives editing priority: the reply quote is hidden and only the edit banner shows, even though
+ * `replyToMessage` is still set underneath and will reappear once editing is cancelled.
+ */
+export const EditingWithPendingReply: Story = {
+    args: {
+        editingMessage: { id: 1, content: 'Original text before the edit', attachments: [] },
+        replyToMessage: mockOwnMessage,
+        onSend: action('onSend'),
+        onSaveEdit: action('onSaveEdit'),
+        onCancelEdit: action('onCancelEdit'),
+        onClearReply: action('onClearReply'),
+    },
+};

--- a/src/pages/client/Chat/MessageInput/MessageInput.tsx
+++ b/src/pages/client/Chat/MessageInput/MessageInput.tsx
@@ -8,7 +8,7 @@ import {
     useRef,
     useState,
 } from 'react';
-import { Mic, Paperclip, Video, X } from 'lucide-react';
+import { Check, Mic, Paperclip, SendHorizontal, Video, X } from 'lucide-react';
 import { Dialog } from 'radix-ui';
 
 import { Button } from '@/components/Button';
@@ -18,8 +18,9 @@ import { EmojiSuggestion, EmojiSuggestionsPopup, EmojiSuggestionsPopupHandle } f
 import { MessageEditorAttachment } from '@/pages/client/Chat/MessageEditorAttachment';
 import { VideoRecorderModal } from '@/pages/client/Chat/VideoRecorderModal';
 import { VoiceRecorderModal } from '@/pages/client/Chat/VoiceRecorderModal';
+import { formatTimestamp } from '@/helpers/formatTimestamp';
 import { AttachmentId, Attachment } from '@/types/attachments';
-import { MessageId } from '@/types/messages';
+import { MessageId, MessageWithUser } from '@/types/messages';
 
 import dialogStyles from '@/components/Popup/Popup.module.css';
 import styles from './MessageInput.module.css';
@@ -32,7 +33,7 @@ type EditingMessage = {
 
 type Props = {
     editingMessage?: EditingMessage | null;
-    replyToPreview?: string | null;
+    replyToMessage?: MessageWithUser | null;
     onSend(text: string, attachmentIds: AttachmentId[]): Promise<void>;
     onSaveEdit?(id: MessageId, text: string, attachmentIds: AttachmentId[]): Promise<void>;
     onCancelEdit?(): void;
@@ -81,7 +82,7 @@ const canCompressFile = (file: File) => file.type.startsWith('video/') || file.t
 const canUploadAsFile = (file: File) =>
     file.type.startsWith('image/') || file.type.startsWith('video/') || file.type.startsWith('audio/');
 
-export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdit, onCancelEdit, onClearReply }: Props) {
+export function MessageInput({ editingMessage, replyToMessage, onSend, onSaveEdit, onCancelEdit, onClearReply }: Props) {
     const [isSending, setIsSending] = useState(false);
     const [text, setText] = useState('');
     const [attachments, setAttachments] = useState<EditorAttachment[]>([]);
@@ -93,7 +94,7 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
     const [isVideoModalOpen, setIsVideoModalOpen] = useState(false);
     const [caret, setCaret] = useState<number | null>(null);
     const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+    const inputRef = useRef<HTMLTextAreaElement>(null);
     const pendingCaretRef = useRef<number | null>(null);
     const suggestionsRef = useRef<EmojiSuggestionsPopupHandle>(null);
 
@@ -137,7 +138,17 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
         setCaret(newCaret);
     };
 
-    const handleTextChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    // grow with the content, capped by the max-height on the textarea
+    useLayoutEffect(() => {
+        const el = inputRef.current;
+        if (!el) {
+            return;
+        }
+        el.style.height = 'auto';
+        el.style.height = `${el.scrollHeight}px`;
+    }, [text]);
+
+    const handleTextChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
         const { value, selectionStart } = e.target;
         if (suggestionsDismissed && selectionStart != null && value[selectionStart - 1] === ':') {
             setSuggestionsDismissed(false);
@@ -146,19 +157,36 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
         setCaret(selectionStart);
     };
 
-    const handleInputKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
-        if (!emojiQuery) {
-            return;
+    const handleInputKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+        if (emojiQuery) {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                setSuggestionsDismissed(true);
+                return;
+            }
+
+            if (suggestionsRef.current?.handleKeyDown(e)) {
+                e.preventDefault();
+                return;
+            }
         }
 
-        if (e.key === 'Escape') {
-            e.preventDefault();
-            setSuggestionsDismissed(true);
-            return;
-        }
+        if (e.key === 'Enter') {
+            if (e.shiftKey || e.ctrlKey) {
+                // Shift+Enter inserts a newline natively; Ctrl+Enter needs it done by hand
+                if (e.ctrlKey) {
+                    e.preventDefault();
+                    const { selectionStart, selectionEnd } = e.currentTarget;
+                    const newCaret = selectionStart + 1;
+                    pendingCaretRef.current = newCaret;
+                    setText(text.slice(0, selectionStart) + '\n' + text.slice(selectionEnd));
+                    setCaret(newCaret);
+                }
+                return;
+            }
 
-        if (suggestionsRef.current?.handleKeyDown(e)) {
             e.preventDefault();
+            e.currentTarget.form?.requestSubmit();
         }
     };
 
@@ -366,11 +394,22 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
                     <X className={styles.replyPreviewClear} onClick={onCancelEdit} />
                 </div>
             )}
-            {!isEditing && replyToPreview && (
+            {!isEditing && replyToMessage && (
                 <div className={styles.replyPreview}>
-                    <span className={styles.replyPreviewText}>
-                        {replyToPreview.length > 50 ? replyToPreview.slice(0, 50) + '…' : replyToPreview}
-                    </span>
+                    <img
+                        className={styles.replyPreviewAvatar}
+                        src={replyToMessage.user.avatarUrl ?? `https://i.pravatar.cc/?img=${replyToMessage.userId}`}
+                        alt={replyToMessage.user.name}
+                    />
+                    <div className={styles.replyPreviewQuote}>
+                        <div className={styles.replyPreviewHeader}>
+                            <span className={styles.replyPreviewAuthor}>{replyToMessage.user.name}</span>
+                            <span className={styles.replyPreviewTime}>
+                                • {formatTimestamp(new Date(replyToMessage.updatedAt))}
+                            </span>
+                        </div>
+                        <div className={styles.replyPreviewText}>{replyToMessage.content}</div>
+                    </div>
                     <X className={styles.replyPreviewClear} onClick={onClearReply} />
                 </div>
             )}
@@ -423,11 +462,11 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
                         query={emojiQuery?.query ?? null}
                         onSelect={applyEmojiSuggestion}
                     />
-                    <input
+                    <textarea
                         ref={inputRef}
-                        type="text"
+                        rows={1}
                         placeholder={isEditing ? 'Edit message…' : 'Type a message...'}
-                        className="w-full bg-gray-700 text-white p-2 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        className="block w-full resize-none max-h-40 overflow-y-auto bg-transparent text-white placeholder-[#5f6a8c] p-2 focus:outline-none"
                         value={text}
                         onChange={handleTextChange}
                         onKeyDown={handleInputKeyDown}
@@ -439,8 +478,9 @@ export function MessageInput({ editingMessage, replyToPreview, onSend, onSaveEdi
                     type="submit"
                     disabled={!canSubmit}
                     className={styles.sendButton}
+                    title={isEditing ? 'Save' : 'Send'}
                 >
-                    {isEditing ? 'Save' : 'Send'}
+                    {isEditing ? <Check /> : <SendHorizontal />}
                 </button>
             </form>
         </div>

--- a/src/pages/client/Chat/MessageReaction/MessageReaction.stories.tsx
+++ b/src/pages/client/Chat/MessageReaction/MessageReaction.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageReaction } from './MessageReaction';
+
+const meta: Meta<typeof MessageReaction> = {
+    title: 'pages/client/Chat/MessageReaction',
+    component: MessageReaction,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageReaction>;
+
+/** A reaction the current user hasn't added. */
+export const Default: Story = {
+    args: {
+        reaction: { code: 'thumbs_up', count: 3 },
+        isMine: false,
+        onAddReaction: action('onAddReaction'),
+        onDeleteReaction: action('onDeleteReaction'),
+    },
+};
+
+/** A reaction the current user has already added, shown highlighted. */
+export const Mine: Story = {
+    args: {
+        reaction: { code: 'heart', count: 1 },
+        isMine: true,
+        onAddReaction: action('onAddReaction'),
+        onDeleteReaction: action('onDeleteReaction'),
+    },
+};

--- a/src/pages/client/Chat/MessageReactions/MessageReactions.stories.tsx
+++ b/src/pages/client/Chat/MessageReactions/MessageReactions.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageReactions } from './MessageReactions';
+import { mockReactions } from '@/test-utils/fixtures/messages';
+
+const meta: Meta<typeof MessageReactions> = {
+    title: 'pages/client/Chat/MessageReactions',
+    component: MessageReactions,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageReactions>;
+
+/** A mix of reactions, one of which belongs to the current user, plus the "add reaction" trigger. */
+export const Default: Story = {
+    args: {
+        reactions: mockReactions,
+        myReactions: ['thumbs_up'],
+        onAddReaction: action('onAddReaction'),
+        onDeleteReaction: action('onDeleteReaction'),
+    },
+};
+
+/** No reactions yet — only the "add reaction" trigger is shown. */
+export const Empty: Story = {
+    args: {
+        reactions: [],
+        myReactions: [],
+        onAddReaction: action('onAddReaction'),
+        onDeleteReaction: action('onDeleteReaction'),
+    },
+};

--- a/src/pages/client/Chat/MessageThreadButton/MessageThreadButton.module.css
+++ b/src/pages/client/Chat/MessageThreadButton/MessageThreadButton.module.css
@@ -1,17 +1,20 @@
 @reference "tailwindcss";
 
 .container {
-    @apply flex flex-row items-center;
+    @apply flex flex-row items-center mt-1;
 }
 
 .button {
-    @apply flex flex-row gap-1 bg-blue-500 border-blue-400 border-2 rounded-lg px-2 py-0.5 cursor-pointer hover:bg-blue-700;
+    @apply inline-flex flex-row items-center gap-1.5 rounded-full border border-[#2b3760] bg-[#111a30] px-3 py-1
+        text-xs font-semibold text-indigo-300 cursor-pointer
+        hover:border-indigo-400 hover:text-indigo-200 hover:bg-[#17213a];
+}
 
-    &.mine {
-        @apply bg-green-500 border-green-400 hover:bg-green-700;
-    }
+.button svg {
+    width: 16px;
+    height: 16px;
 }
 
 .counter {
-    @apply text-yellow-700 px-1;
+    @apply px-1.5 text-xs font-bold text-[#9ca6ff];
 }

--- a/src/pages/client/Chat/MessageThreadButton/MessageThreadButton.stories.tsx
+++ b/src/pages/client/Chat/MessageThreadButton/MessageThreadButton.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { MessageThreadButton } from './MessageThreadButton';
+
+const meta: Meta<typeof MessageThreadButton> = {
+    title: 'pages/client/Chat/MessageThreadButton',
+    component: MessageThreadButton,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageThreadButton>;
+
+/** A thread button with a few replies. */
+export const Default: Story = {
+    args: {
+        count: 3,
+        onToggleThread: action('onToggleThread'),
+    },
+};
+
+/** A thread with no replies yet. */
+export const NoReplies: Story = {
+    args: {
+        count: 0,
+        onToggleThread: action('onToggleThread'),
+    },
+};
+
+/** A heavily-discussed thread. */
+export const ManyReplies: Story = {
+    args: {
+        count: 128,
+        onToggleThread: action('onToggleThread'),
+    },
+};

--- a/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewComponent.module.css
+++ b/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewComponent.module.css
@@ -1,42 +1,22 @@
 @reference "tailwindcss";
 
 .container {
-    @apply relative block p-2 pl-6
-        bg-[#19334d]
-        border border-gray-700 rounded-lg;
-}
-
-.container::before {
-    @apply w-2 rounded-bl-lg rounded-tl-lg;
-    content: '';
-    --size: 5px;
-    --color: #ffb325;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: var(--size);
-    bottom: 0;
-    background: repeating-linear-gradient(
-            -45deg,
-            transparent,
-            transparent var(--size),
-            var(--color) var(--size),
-            var(--color) calc(var(--size) * 2)
-    );
+    @apply block p-4 bg-[#101830] border border-[#232e4d] rounded-xl
+        hover:border-[#3a4a7d] transition-colors;
 }
 
 .siteName {
-    @apply font-bold text-[#699cce];
+    @apply text-xs font-bold uppercase tracking-wider text-indigo-300;
 }
 
 .title {
-    @apply text-white;
+    @apply mt-1 font-semibold text-white;
 }
 
 .description {
-    @apply text-gray-400;
+    @apply mt-0.5 text-sm text-[#8b93b0];
 }
 
 .image {
-    @apply mt-2 max-w-full rounded w-100 h-auto;
+    @apply mt-3 max-w-full rounded-lg w-100 h-auto;
 }

--- a/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewComponent.stories.tsx
+++ b/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewComponent.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageUrlPreviewComponent } from './MessageUrlPreviewComponent';
+import { mockUrlPreview } from '@/test-utils/fixtures/messages';
+
+const meta: Meta<typeof MessageUrlPreviewComponent> = {
+    title: 'pages/client/Chat/MessageUrlPreviewComponent',
+    component: MessageUrlPreviewComponent,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageUrlPreviewComponent>;
+
+/** A full preview with site name, title, description and thumbnail. */
+export const Default: Story = {
+    args: {
+        preview: mockUrlPreview,
+    },
+};
+
+/** A minimal preview with only a title — description and thumbnail omitted. */
+export const TitleOnly: Story = {
+    args: {
+        preview: {
+            ...mockUrlPreview,
+            description: null,
+            thumbnailUrl: null,
+            siteName: null,
+        },
+    },
+};

--- a/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewsComponent.stories.tsx
+++ b/src/pages/client/Chat/MessageUrlPreviewsComponent/MessageUrlPreviewsComponent.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MessageUrlPreviewsComponent } from './MessageUrlPreviewsComponent';
+import { mockUrlPreview } from '@/test-utils/fixtures/messages';
+
+const meta: Meta<typeof MessageUrlPreviewsComponent> = {
+    title: 'pages/client/Chat/MessageUrlPreviewsComponent',
+    component: MessageUrlPreviewsComponent,
+};
+export default meta;
+
+type Story = StoryObj<typeof MessageUrlPreviewsComponent>;
+
+/** A single link preview with a thumbnail, title and description. */
+export const Default: Story = {
+    args: {
+        urlPreviews: [mockUrlPreview],
+    },
+};
+
+/** No previews — renders nothing. */
+export const Empty: Story = {
+    args: {
+        urlPreviews: [],
+    },
+};

--- a/src/pages/client/Chat/MessagesList/MessagesList.module.css
+++ b/src/pages/client/Chat/MessagesList/MessagesList.module.css
@@ -1,11 +1,11 @@
 @reference "tailwindcss";
 
 .container {
-    @apply relative flex-1 flex flex-col bg-gray-900;
+    @apply relative flex-1 flex flex-col bg-[#0b1122];
 }
 
 .header {
-    @apply text-lg text-orange-400 font-bold m-2 mb-4;
+    @apply text-lg text-indigo-300 font-bold m-2 mb-4;
 }
 
 .scrollArea {
@@ -21,9 +21,9 @@
     z-index: 10;
     cursor: pointer;
     opacity: 0.5;
-    background-color: rgb(42, 68, 133);
+    background-color: var(--color-indigo-600);
     border-radius: 50%;
-    border: solid 1px white;
+    border: solid 1px var(--color-indigo-300);
 
     &:hover {
         opacity: 1;

--- a/src/pages/client/Chat/ProgressBar/ProgressBar.stories.tsx
+++ b/src/pages/client/Chat/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ProgressBar } from './ProgressBar';
+
+const meta: Meta<typeof ProgressBar> = {
+    title: 'pages/client/Chat/ProgressBar',
+    component: ProgressBar,
+};
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+/** A progress bar partway through an upload. */
+export const Default: Story = {
+    args: {
+        label: 'uploading-video.mp4',
+        progress: 0.45,
+    },
+};
+
+/** A freshly started upload. */
+export const JustStarted: Story = {
+    args: {
+        label: 'photo.jpg',
+        progress: 0,
+    },
+};
+
+/** A completed upload. */
+export const Complete: Story = {
+    args: {
+        label: 'document.pdf',
+        progress: 1,
+    },
+};

--- a/src/pages/client/Chat/ReactionSelectionDialog/ReactionSelectionDialog.stories.tsx
+++ b/src/pages/client/Chat/ReactionSelectionDialog/ReactionSelectionDialog.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { ReactionSelectionDialog } from './ReactionSelectionDialog';
+import { ALL_REACTION_CODES } from '@/pages/client/Chat/emojis';
+
+const meta: Meta<typeof ReactionSelectionDialog> = {
+    title: 'pages/client/Chat/ReactionSelectionDialog',
+    component: ReactionSelectionDialog,
+};
+export default meta;
+
+type Story = StoryObj<typeof ReactionSelectionDialog>;
+
+/** Click the emoji trigger to open the category/search picker. */
+export const Default: Story = {
+    args: {
+        reactions: ALL_REACTION_CODES,
+        myReactions: [],
+        onSelect: action('onSelect'),
+    },
+};
+
+/** A couple of reactions have already been picked, so they're excluded from the list. */
+export const WithExistingReactions: Story = {
+    args: {
+        reactions: ALL_REACTION_CODES,
+        myReactions: ['thumbs_up', 'heart'],
+        onSelect: action('onSelect'),
+    },
+};

--- a/src/pages/client/Chat/Thread/Thread.module.css
+++ b/src/pages/client/Chat/Thread/Thread.module.css
@@ -1,12 +1,25 @@
 @reference "tailwindcss";
 
 .container {
-    @apply relative flex flex-col bg-gray-900;
+    @apply relative flex flex-col bg-[#131a30] border-l border-[#2a3557]
+        shadow-[inset_1px_0_0_rgba(129,140,248,0.08)];
     flex: 0 1 30%;
 }
 
 .header {
-    @apply flex flex-row items-center text-lg text-orange-400 font-bold m-2 mb-4;
+    @apply flex flex-row items-center gap-2 m-0 mb-2 px-4 py-3 border-b border-[#232e4d];
+}
+
+.headerIcon {
+    @apply w-5 h-5 text-indigo-300;
+}
+
+.headerTitle {
+    @apply text-lg font-bold text-white;
+}
+
+.closeButton {
+    @apply ml-auto w-5 h-5 cursor-pointer text-[#7d87a8] hover:text-white;
 }
 
 .scrollArea {
@@ -21,9 +34,9 @@
     z-index: 10;
     cursor: pointer;
     opacity: 0.5;
-    background-color: rgb(42, 68, 133);
+    background-color: var(--color-indigo-600);
     border-radius: 50%;
-    border: solid 1px white;
+    border: solid 1px var(--color-indigo-300);
 
     &:hover {
         opacity: 1;

--- a/src/pages/client/Chat/Thread/Thread.tsx
+++ b/src/pages/client/Chat/Thread/Thread.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { PanelRightClose } from 'lucide-react';
+import { MessagesSquare, X } from 'lucide-react';
 import { useApolloClient } from '@apollo/client/react';
 
 import { WebSocketEventEmitter } from '@/communication/WebSocketEventEmitter';
@@ -35,11 +35,12 @@ export const Thread = ({ rootMessage, eventEmitter, onCloseThread }: Props) => {
 
     const header = (
         <>
-            <PanelRightClose
-                className="cursor-pointer inline-block mr-2 text-red-500"
+            <MessagesSquare className={styles.headerIcon} />
+            <span className={styles.headerTitle}>Thread</span>
+            <X
+                className={styles.closeButton}
                 onClick={onCloseThread}
             />
-            Thread
         </>
     );
 

--- a/src/pages/client/Chat/UserSettingsPopup/UserSettingsPopup.stories.tsx
+++ b/src/pages/client/Chat/UserSettingsPopup/UserSettingsPopup.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { UserSettingsPopup } from './UserSettingsPopup';
+import { withUser } from '@/test-utils/decorators/withUser';
+
+const meta: Meta<typeof UserSettingsPopup> = {
+    title: 'pages/client/Chat/UserSettingsPopup',
+    component: UserSettingsPopup,
+    decorators: [withUser()],
+};
+export default meta;
+
+type Story = StoryObj<typeof UserSettingsPopup>;
+
+/** The avatar trigger; click it to open the profile popup. */
+export const Default: Story = {
+    args: {},
+};

--- a/src/pages/client/Chat/VideoRecorderModal/VideoRecorderModal.stories.tsx
+++ b/src/pages/client/Chat/VideoRecorderModal/VideoRecorderModal.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { VideoRecorderModal } from './VideoRecorderModal';
+import { withFakeMediaDevices } from '@/test-utils/decorators/withFakeMediaDevices';
+
+/**
+ * Uses a synthetic (canvas-captured) video MediaStream in place of a real camera, so the
+ * recording/pause/preview flow is genuinely exercised via the browser's real MediaRecorder — see
+ * src/test-utils/decorators/withFakeMediaDevices.tsx. Requires a browser that supports
+ * HTMLCanvasElement.captureStream (all evergreen browsers).
+ */
+const meta: Meta<typeof VideoRecorderModal> = {
+    title: 'pages/client/Chat/VideoRecorderModal',
+    component: VideoRecorderModal,
+};
+export default meta;
+
+type Story = StoryObj<typeof VideoRecorderModal>;
+
+/** A live recording session using a synthetic camera stream. */
+export const Recording: Story = {
+    decorators: [withFakeMediaDevices('video')],
+    args: {
+        onClose: action('onClose'),
+        onRecorded: action('onRecorded'),
+    },
+};
+
+/** The camera permission was denied or is unavailable. */
+export const PermissionDenied: Story = {
+    decorators: [withFakeMediaDevices('deny')],
+    args: {
+        onClose: action('onClose'),
+        onRecorded: action('onRecorded'),
+    },
+};

--- a/src/pages/client/Chat/VoiceRecorderModal/VoiceRecorderModal.stories.tsx
+++ b/src/pages/client/Chat/VoiceRecorderModal/VoiceRecorderModal.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { VoiceRecorderModal } from './VoiceRecorderModal';
+import { withFakeMediaDevices } from '@/test-utils/decorators/withFakeMediaDevices';
+
+/**
+ * Uses a synthetic (oscillator-generated) audio MediaStream in place of a real microphone, so
+ * the recording/pause/preview flow is genuinely exercised via the browser's real MediaRecorder —
+ * see src/test-utils/decorators/withFakeMediaDevices.tsx. Requires a browser that supports
+ * AudioContext.createMediaStreamDestination (all evergreen browsers).
+ */
+const meta: Meta<typeof VoiceRecorderModal> = {
+    title: 'pages/client/Chat/VoiceRecorderModal',
+    component: VoiceRecorderModal,
+};
+export default meta;
+
+type Story = StoryObj<typeof VoiceRecorderModal>;
+
+/** A live recording session using a synthetic microphone stream. */
+export const Recording: Story = {
+    decorators: [withFakeMediaDevices('audio')],
+    args: {
+        onClose: action('onClose'),
+        onRecorded: action('onRecorded'),
+    },
+};
+
+/** The microphone permission was denied or is unavailable. */
+export const PermissionDenied: Story = {
+    decorators: [withFakeMediaDevices('deny')],
+    args: {
+        onClose: action('onClose'),
+        onRecorded: action('onRecorded'),
+    },
+};

--- a/src/pages/client/Chat/WorkspaceCreateModal/WorkspaceCreateModal.stories.tsx
+++ b/src/pages/client/Chat/WorkspaceCreateModal/WorkspaceCreateModal.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { gql } from '@apollo/client';
+import { MockedProvider } from '@apollo/client/testing/react';
+import { action } from 'storybook/actions';
+import { WorkspaceCreateModal } from './WorkspaceCreateModal';
+
+const ADD_WORKSPACE_MUTATION = gql`
+    mutation AddWorkspace($name: String!) {
+        workspaces {
+            addWorkspace(workspaceDto: { name: $name }) {
+                id
+                name
+                createdAt
+                updatedAt
+            }
+        }
+    }
+`;
+
+const mocks = [
+    {
+        request: { query: ADD_WORKSPACE_MUTATION, variables: { name: 'Design Team' } },
+        result: {
+            data: {
+                workspaces: {
+                    addWorkspace: { id: 3, name: 'Design Team', createdAt: '2026-01-15T10:00:00Z', updatedAt: '2026-01-15T10:00:00Z' },
+                },
+            },
+        },
+    },
+];
+
+/** Only the form/submit path is Apollo-driven; the story wraps in MockedProvider so a real submit ("Design Team") resolves without hitting a network. */
+const meta: Meta<typeof WorkspaceCreateModal> = {
+    title: 'pages/client/Chat/WorkspaceCreateModal',
+    component: WorkspaceCreateModal,
+    decorators: [(Story) => (
+        <MockedProvider mocks={mocks}>
+            <Story />
+        </MockedProvider>
+    )],
+};
+export default meta;
+
+type Story = StoryObj<typeof WorkspaceCreateModal>;
+
+/** The create-workspace dialog, ready for input. */
+export const Default: Story = {
+    args: {
+        onClose: action('onClose'),
+        onWorkspaceCreated: action('onWorkspaceCreated'),
+    },
+};

--- a/src/pages/client/Chat/WorkspacesList/WorkspacesList.stories.tsx
+++ b/src/pages/client/Chat/WorkspacesList/WorkspacesList.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { gql } from '@apollo/client';
+import { MockedProvider } from '@apollo/client/testing/react';
+import { withWorkspacesList } from '@/test-utils/decorators/withWorkspacesList';
+import { withUser } from '@/test-utils/decorators/withUser';
+import { WorkspacesList } from './WorkspacesList';
+
+const ADD_WORKSPACE_MUTATION = gql`
+    mutation AddWorkspace($name: String!) {
+        workspaces {
+            addWorkspace(workspaceDto: { name: $name }) {
+                id
+                name
+                createdAt
+                updatedAt
+            }
+        }
+    }
+`;
+
+const mocks = [
+    {
+        request: { query: ADD_WORKSPACE_MUTATION, variables: { name: 'New Team' } },
+        result: {
+            data: {
+                workspaces: {
+                    addWorkspace: { id: 3, name: 'New Team', createdAt: '2026-01-15T10:00:00Z', updatedAt: '2026-01-15T10:00:00Z' },
+                },
+            },
+        },
+    },
+];
+
+/** Fully context-driven (no props). Composes the WorkspacesList + UserContext decorators plus a MockedProvider so opening "+" (WorkspaceCreateModal) and submitting "New Team" also works end to end. */
+const meta: Meta<typeof WorkspacesList> = {
+    title: 'pages/client/Chat/WorkspacesList',
+    component: WorkspacesList,
+    decorators: [
+        withWorkspacesList(),
+        withUser(),
+        (Story) => (
+            <MockedProvider mocks={mocks}>
+                <Story />
+            </MockedProvider>
+        ),
+    ],
+};
+export default meta;
+
+type Story = StoryObj<typeof WorkspacesList>;
+
+/** The workspace switcher with two workspaces and the current user's avatar. */
+export const Default: Story = {
+    args: {},
+};

--- a/src/pages/dashboard/components/ChannelGroupEditor/ChannelGroupEditor.module.css
+++ b/src/pages/dashboard/components/ChannelGroupEditor/ChannelGroupEditor.module.css
@@ -35,7 +35,7 @@
 }
 
 .channelListItem {
-    @apply border-2 border-amber-600 p-2 rounded-lg;
+    @apply border-2 border-indigo-500 p-2 rounded-lg;
 }
 
 .controls {

--- a/src/pages/dashboard/components/MainMenu/MainMenu.module.css
+++ b/src/pages/dashboard/components/MainMenu/MainMenu.module.css
@@ -6,7 +6,7 @@
 }
 
 .menuItem {
-    @apply flex flex-row items-stretch justify-items-stretch justify-stretch p-0 m-0 outline-0 font-bold hover:bg-amber-600;
+    @apply flex flex-row items-stretch justify-items-stretch justify-stretch p-0 m-0 outline-0 font-bold hover:bg-indigo-600;
     color: var(--main-menu-text-color);
     background-color: var(--main-menu-bg-color);
 }
@@ -20,5 +20,5 @@
 }
 
 .activeLink {
-    @apply bg-amber-100 text-black!;
+    @apply bg-indigo-100 text-black!;
 }

--- a/src/pages/dashboard/components/Tabs/Tabs.module.css
+++ b/src/pages/dashboard/components/Tabs/Tabs.module.css
@@ -25,11 +25,11 @@
 }
 
 .tabsTrigger:hover {
-    @apply text-amber-500;
+    @apply text-indigo-400;
 }
 
 .tabsTrigger[data-state=active] {
-    @apply font-bold text-amber-500;
+    @apply font-bold text-indigo-400;
 }
 
 .tabsList {

--- a/src/test-utils/decorators/withChannelTypesList.tsx
+++ b/src/test-utils/decorators/withChannelTypesList.tsx
@@ -1,0 +1,15 @@
+import type { Decorator } from '@storybook/react-vite';
+import { ChannelTypesListContext } from '@/contexts/ChannelTypesListContext';
+import { mockChannelTypesList } from '@/test-utils/fixtures/channelTypes';
+
+const defaultValue = {
+    channelTypes: mockChannelTypesList,
+    refetch: () => {},
+};
+
+/** Supplies a static ChannelTypesListContext value, bypassing the real provider's useSuspenseQuery. */
+export const withChannelTypesList = (value = defaultValue): Decorator => (Story) => (
+    <ChannelTypesListContext.Provider value={value}>
+        <Story />
+    </ChannelTypesListContext.Provider>
+);

--- a/src/test-utils/decorators/withFakeMediaDevices.tsx
+++ b/src/test-utils/decorators/withFakeMediaDevices.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import type { Decorator } from '@storybook/react-vite';
+import { createFakeAudioStream, createFakeVideoStream } from '@/test-utils/mocks/fakeMediaDevices';
+
+/**
+ * Patches navigator.mediaDevices.getUserMedia for the story's lifetime so components using
+ * useRecordingSession get a real (synthetic) MediaStream instead of a permission prompt.
+ * 'deny' simulates the user rejecting the permission prompt, exercising the error state.
+ */
+export const withFakeMediaDevices = (kind: 'audio' | 'video' | 'deny'): Decorator => (Story) => {
+    useEffect(() => {
+        if (!navigator.mediaDevices) {
+            return;
+        }
+        const original = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+
+        navigator.mediaDevices.getUserMedia = async () => {
+            if (kind === 'deny') {
+                throw new DOMException('Permission denied', 'NotAllowedError');
+            }
+            return kind === 'audio' ? createFakeAudioStream() : createFakeVideoStream();
+        };
+
+        return () => {
+            navigator.mediaDevices.getUserMedia = original;
+        };
+    }, []);
+
+    return <Story />;
+};

--- a/src/test-utils/decorators/withUser.tsx
+++ b/src/test-utils/decorators/withUser.tsx
@@ -1,0 +1,15 @@
+import type { Decorator } from '@storybook/react-vite';
+import { UserContext, UserContextData } from '@/contexts/UserContext';
+import { mockUser1 } from '@/test-utils/fixtures/users';
+
+const defaultUserContextValue: UserContextData = {
+    user: mockUser1,
+    logout: () => {},
+};
+
+/** Supplies a static UserContext value instead of the real UserProvider, which fetches over Apollo and redirects on mount. */
+export const withUser = (value: UserContextData = defaultUserContextValue): Decorator => (Story) => (
+    <UserContext.Provider value={value}>
+        <Story />
+    </UserContext.Provider>
+);

--- a/src/test-utils/decorators/withWorkspaceChannelsList.tsx
+++ b/src/test-utils/decorators/withWorkspaceChannelsList.tsx
@@ -1,0 +1,17 @@
+import type { Decorator } from '@storybook/react-vite';
+import { WorkspaceChannelsListContext } from '@/contexts/WorkspaceChannelsListContext';
+import { mockChannel1, mockChannelsList } from '@/test-utils/fixtures/channels';
+
+const defaultValue = {
+    channels: mockChannelsList,
+    activeChannel: mockChannel1,
+    refetch: () => {},
+    setActiveChannel: () => {},
+};
+
+/** Supplies a static WorkspaceChannelsListContext value instead of the real provider, which fetches over Apollo on mount. */
+export const withWorkspaceChannelsList = (value = defaultValue): Decorator => (Story) => (
+    <WorkspaceChannelsListContext.Provider value={value}>
+        <Story />
+    </WorkspaceChannelsListContext.Provider>
+);

--- a/src/test-utils/decorators/withWorkspacesList.tsx
+++ b/src/test-utils/decorators/withWorkspacesList.tsx
@@ -1,0 +1,18 @@
+import type { Decorator } from '@storybook/react-vite';
+import { WorkspacesListContext } from '@/contexts/WorkspacesListContext';
+import { mockWorkspace1, mockWorkspacesList } from '@/test-utils/fixtures/workspaces';
+
+const defaultValue = {
+    workspacesList: mockWorkspacesList,
+    setWorkspacesList: () => {},
+    activeWorkspaceId: mockWorkspace1.id,
+    setActiveWorkspaceId: () => {},
+    refetch: () => {},
+};
+
+/** Supplies a static WorkspacesListContext value instead of the real provider, which fetches over Apollo on mount. */
+export const withWorkspacesList = (value = defaultValue): Decorator => (Story) => (
+    <WorkspacesListContext.Provider value={value}>
+        <Story />
+    </WorkspacesListContext.Provider>
+);

--- a/src/test-utils/fixtures/attachments.ts
+++ b/src/test-utils/fixtures/attachments.ts
@@ -1,0 +1,100 @@
+import { Attachment } from '@/types/attachments';
+import { mockUserId1 } from './users';
+
+/**
+ * `urlPath` values are placeholders — MessageAttachmentComponent/MessageEditorAttachment build
+ * their display URL via a hardcoded `http://localhost:9000/chatney/${urlPath}` (see
+ * STORYBOOK_COVERAGE.md caveats). `src/test-utils/mocks/attachmentUrlHandlers.ts` intercepts
+ * that host in Storybook and serves real sample bytes based on the file extension, so previews
+ * render normally despite the fake path.
+ */
+const now = new Date('2026-01-15T10:00:00Z');
+
+export const mockImageAttachment: Attachment = {
+    id: 1,
+    userId: mockUserId1,
+    urlPath: 'attachments/sample-image.jpg',
+    originalFileName: 'sunset.jpg',
+    extension: 'jpg',
+    mimeType: 'image/jpeg',
+    size: 245_000,
+    type: 'image',
+    asFile: false,
+    width: 1200,
+    height: 800,
+    duration: null,
+    createdAt: now,
+    updatedAt: now,
+};
+
+export const mockGifAttachment: Attachment = {
+    ...mockImageAttachment,
+    id: 2,
+    urlPath: 'attachments/sample.gif',
+    originalFileName: 'reaction.gif',
+    extension: 'gif',
+    mimeType: 'image/gif',
+    type: 'gif',
+};
+
+export const mockVideoAttachment: Attachment = {
+    id: 3,
+    userId: mockUserId1,
+    urlPath: 'attachments/sample-video.mp4',
+    originalFileName: 'demo.mp4',
+    extension: 'mp4',
+    mimeType: 'video/mp4',
+    size: 3_400_000,
+    type: 'video',
+    asFile: false,
+    width: 1280,
+    height: 720,
+    duration: 12,
+    createdAt: now,
+    updatedAt: now,
+};
+
+export const mockAudioAttachment: Attachment = {
+    id: 4,
+    userId: mockUserId1,
+    urlPath: 'attachments/sample-audio.mp3',
+    originalFileName: 'voice-note.mp3',
+    extension: 'mp3',
+    mimeType: 'audio/mpeg',
+    size: 180_000,
+    type: 'audio',
+    asFile: false,
+    width: null,
+    height: null,
+    duration: 8,
+    createdAt: now,
+    updatedAt: now,
+};
+
+export const mockBinaryAttachment: Attachment = {
+    id: 5,
+    userId: mockUserId1,
+    urlPath: 'attachments/report.pdf',
+    originalFileName: 'quarterly-report.pdf',
+    extension: 'pdf',
+    mimeType: 'application/pdf',
+    size: 512_000,
+    type: 'binary',
+    asFile: true,
+    width: null,
+    height: null,
+    duration: null,
+    createdAt: now,
+    updatedAt: now,
+};
+
+/**
+ * Publicly hosted sample media, for components that take an explicit `attachmentUrl` prop
+ * rather than deriving it from `urlPath`, and for `attachmentUrlHandlers.ts` to proxy real bytes
+ * through. All four hosts are known to serve permissive CORS headers, which the MSW handler
+ * needs since it reads the response body rather than just redirecting to it.
+ */
+export const samplePlaceholderImageUrl = 'https://picsum.photos/id/1015/800/600';
+export const samplePlaceholderGifUrl = 'https://upload.wikimedia.org/wikipedia/commons/b/b1/Loading_icon.gif';
+export const samplePlaceholderVideoUrl = 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4';
+export const samplePlaceholderAudioUrl = 'https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3';

--- a/src/test-utils/fixtures/channelTypes.ts
+++ b/src/test-utils/fixtures/channelTypes.ts
@@ -1,0 +1,6 @@
+import { ChannelType } from '@/types/channelTypes';
+
+export const mockChannelType1: ChannelType = { id: 1, name: 'Public', key: 'public', baseRoleId: 1 };
+export const mockChannelType2: ChannelType = { id: 2, name: 'Private', key: 'private', baseRoleId: 2 };
+
+export const mockChannelTypesList: ChannelType[] = [mockChannelType1, mockChannelType2];

--- a/src/test-utils/fixtures/channels.ts
+++ b/src/test-utils/fixtures/channels.ts
@@ -1,0 +1,22 @@
+import { Channel } from '@/types/channels';
+import { ChannelListItem } from '@/pages/client/Chat/types';
+import { mockWorkspace1 } from './workspaces';
+import { mockChannelType1 } from './channelTypes';
+
+export const mockChannel1: Channel = {
+    id: 1,
+    name: 'general',
+    channelTypeId: mockChannelType1.id,
+    workspaceId: mockWorkspace1.id,
+};
+
+export const mockChannel2: Channel = {
+    id: 2,
+    name: 'random',
+    channelTypeId: mockChannelType1.id,
+    workspaceId: mockWorkspace1.id,
+};
+
+export const mockChannelsList: Channel[] = [mockChannel1, mockChannel2];
+
+export const mockChannelListItem1: ChannelListItem = { id: mockChannel1.id, name: mockChannel1.name };

--- a/src/test-utils/fixtures/messages.ts
+++ b/src/test-utils/fixtures/messages.ts
@@ -1,0 +1,111 @@
+import { MessageWithUser, Reaction, ReplyToMessage, UrlPreview } from '@/types/messages';
+import { mockChannel1 } from './channels';
+import { mockMessageUser1, mockMessageUser2, mockUserId1, mockUserId2 } from './users';
+import { mockImageAttachment } from './attachments';
+
+const createdAt = new Date('2026-01-15T10:00:00Z');
+const updatedAt = createdAt;
+
+export const mockReactions: Reaction[] = [
+    { code: 'thumbs_up', count: 3 },
+    { code: 'heart', count: 1 },
+    { code: 'joy', count: 0 },
+];
+
+export const mockUrlPreview: UrlPreview = {
+    id: 'preview-1',
+    createdAt,
+    updatedAt,
+    url: 'https://storybook.js.org',
+    title: 'Storybook: Frontend workshop for UI development',
+    description: 'Storybook is a frontend workshop for building UI components and pages in isolation.',
+    thumbnailUrl: 'https://picsum.photos/id/180/400/210',
+    videoThumbnailUrl: null,
+    siteName: 'Storybook',
+    favIconUrl: 'https://storybook.js.org/favicon.ico',
+    type: 'website',
+    author: null,
+    thumbnailWidth: 400,
+    thumbnailHeight: 210,
+};
+
+export const mockReplyToMessage: ReplyToMessage = {
+    id: 100,
+    userId: mockUserId2,
+    content: 'Can someone double-check the deploy checklist?',
+};
+
+export const mockPlainMessage: MessageWithUser = {
+    id: 1,
+    channelId: mockChannel1.id,
+    userId: mockUserId1,
+    content: 'Hey team, the new build is looking great!',
+    attachments: [],
+    status: 'sent',
+    createdAt,
+    updatedAt,
+    reactions: [],
+    myReactions: [],
+    urlPreviews: [],
+    parentId: null,
+    childrenCount: 0,
+    replyTo: null,
+    user: mockMessageUser1,
+};
+
+export const mockOwnMessage: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 2,
+    userId: mockUserId2,
+    user: mockMessageUser2,
+    content: 'Agreed — shipping it today.',
+};
+
+export const mockMessageWithReactions: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 3,
+    content: 'Who wants to grab lunch?',
+    reactions: mockReactions,
+    myReactions: ['thumbs_up'],
+};
+
+export const mockMessageWithAttachment: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 4,
+    content: 'Here is the sunset shot from yesterday.',
+    attachments: [mockImageAttachment],
+};
+
+export const mockMessageWithUrlPreview: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 5,
+    content: 'Check this out: https://storybook.js.org',
+    urlPreviews: [mockUrlPreview],
+};
+
+export const mockEditedMessage: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 6,
+    content: 'Fixed a typo in this message.',
+    updatedAt: new Date('2026-01-15T10:05:00Z'),
+};
+
+export const mockThreadedMessage: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 7,
+    content: 'Kicking off a thread here — thoughts?',
+    childrenCount: 4,
+};
+
+export const mockReplyMessage: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 8,
+    content: 'Sounds good to me.',
+    replyTo: mockReplyToMessage.id,
+};
+
+export const mockMultilineMessage: MessageWithUser = {
+    ...mockPlainMessage,
+    id: 9,
+    content: 'Line one of the update.\nLine two with more detail.\n\nLine four after a blank line.',
+};

--- a/src/test-utils/fixtures/users.ts
+++ b/src/test-utils/fixtures/users.ts
@@ -1,0 +1,39 @@
+import { User, UserId } from '@/types/users';
+import { MessageUser } from '@/types/messages';
+
+export const mockUserId1: UserId = 'user-1';
+export const mockUserId2: UserId = 'user-2';
+
+export const mockUser1: User = {
+    id: mockUserId1,
+    name: 'Ada Lovelace',
+    active: true,
+    verified: true,
+    banned: false,
+    muted: false,
+    email: 'ada@chatney.dev',
+    workspaces: [],
+};
+
+export const mockUser2: User = {
+    id: mockUserId2,
+    name: 'Grace Hopper',
+    active: true,
+    verified: true,
+    banned: false,
+    muted: false,
+    email: 'grace@chatney.dev',
+    workspaces: [],
+};
+
+export const mockMessageUser1: MessageUser = {
+    id: mockUserId1,
+    name: mockUser1.name,
+    avatarUrl: `https://i.pravatar.cc/150?u=${mockUserId1}`,
+};
+
+export const mockMessageUser2: MessageUser = {
+    id: mockUserId2,
+    name: mockUser2.name,
+    avatarUrl: `https://i.pravatar.cc/150?u=${mockUserId2}`,
+};

--- a/src/test-utils/fixtures/workspaces.ts
+++ b/src/test-utils/fixtures/workspaces.ts
@@ -1,0 +1,6 @@
+import { Workspace } from '@/types/workspaces';
+
+export const mockWorkspace1: Workspace = { id: 1, name: 'Chatney HQ' };
+export const mockWorkspace2: Workspace = { id: 2, name: 'Design Team' };
+
+export const mockWorkspacesList: Workspace[] = [mockWorkspace1, mockWorkspace2];

--- a/src/test-utils/mocks/attachmentUrlHandlers.ts
+++ b/src/test-utils/mocks/attachmentUrlHandlers.ts
@@ -1,0 +1,61 @@
+import { http, HttpResponse } from 'msw';
+import {
+    samplePlaceholderAudioUrl,
+    samplePlaceholderGifUrl,
+    samplePlaceholderImageUrl,
+    samplePlaceholderVideoUrl,
+} from '@/test-utils/fixtures/attachments';
+
+const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+    '.gif': 'image/gif',
+    '.mp4': 'video/mp4',
+    '.mp3': 'audio/mpeg',
+};
+
+const resolveSampleUrl = (pathname: string) => {
+    if (pathname.endsWith('.gif')) {
+        return samplePlaceholderGifUrl;
+    }
+    if (pathname.endsWith('.mp4')) {
+        return samplePlaceholderVideoUrl;
+    }
+    if (pathname.endsWith('.mp3')) {
+        return samplePlaceholderAudioUrl;
+    }
+    return samplePlaceholderImageUrl;
+};
+
+/**
+ * MessageAttachmentComponent/MessageEditorAttachment build their display URL from a hardcoded
+ * `http://localhost:9000/chatney/...` base (real local MinIO endpoint in dev — see
+ * STORYBOOK_COVERAGE.md caveats), which nothing is listening on inside Storybook. Rather than
+ * running a real server on port 9000 (risking a clash with an actual local MinIO instance), this
+ * intercepts those specific requests at the browser network layer.
+ *
+ * It fetches and re-serves real sample bytes (rather than returning an HTTP redirect) so `<img>`,
+ * `<video>`, and `<audio>` elements all see a normal 200 response straight from the requested
+ * URL — a redirect works for `<img>` but is unreliable for media elements that issue Range
+ * requests through the service worker. All sample hosts are CORS-permissive so the body can
+ * actually be read here.
+ */
+export const attachmentUrlHandlers = [
+    http.get('http://localhost:9000/chatney/*', async ({ request }) => {
+        const { pathname } = new URL(request.url);
+        const sampleUrl = resolveSampleUrl(pathname);
+        const extension = Object.keys(CONTENT_TYPE_BY_EXTENSION).find(ext => pathname.endsWith(ext));
+
+        const response = await fetch(sampleUrl);
+        if (!response.ok) {
+            return new HttpResponse(null, { status: response.status });
+        }
+
+        const body = await response.arrayBuffer();
+        return new HttpResponse(body, {
+            status: 200,
+            headers: {
+                'Content-Type': response.headers.get('Content-Type')
+                    ?? (extension ? CONTENT_TYPE_BY_EXTENSION[extension] : 'image/jpeg'),
+            },
+        });
+    }),
+];

--- a/src/test-utils/mocks/fakeMediaDevices.ts
+++ b/src/test-utils/mocks/fakeMediaDevices.ts
@@ -1,0 +1,31 @@
+/** A silent, synthetic audio MediaStream (440Hz oscillator into a stream destination) — lets MediaRecorder actually produce real chunks without a microphone. */
+export const createFakeAudioStream = (): MediaStream => {
+    const audioContext = new AudioContext();
+    const oscillator = audioContext.createOscillator();
+    const destination = audioContext.createMediaStreamDestination();
+    oscillator.frequency.value = 440;
+    oscillator.connect(destination);
+    oscillator.start();
+    return destination.stream;
+};
+
+/** An animated canvas captured as a MediaStream — lets MediaRecorder produce real video chunks without a camera. */
+export const createFakeVideoStream = (): MediaStream => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 320;
+    canvas.height = 240;
+    const ctx = canvas.getContext('2d');
+    let hue = 0;
+
+    const draw = () => {
+        hue = (hue + 2) % 360;
+        if (ctx) {
+            ctx.fillStyle = `hsl(${hue}, 70%, 50%)`;
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+        }
+        requestAnimationFrame(draw);
+    };
+    draw();
+
+    return (canvas as HTMLCanvasElement & { captureStream(frameRate?: number): MediaStream }).captureStream(15);
+};

--- a/src/test-utils/mocks/webSocketEventEmitter.ts
+++ b/src/test-utils/mocks/webSocketEventEmitter.ts
@@ -1,0 +1,4 @@
+import { WebSocketEventEmitter } from '@/communication/WebSocketEventEmitter';
+
+/** Inert WebSocketEventEmitter instance to satisfy props that require one; stories can dispatchEvent on it manually if needed. */
+export const createMockEventEmitter = () => new WebSocketEventEmitter();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,17 @@
 import path from 'path';
-import {defineConfig} from 'vite';
+import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-    plugins: [tailwindcss(), react()],
-    resolve: {
-        alias: {
-            '@': path.resolve(__dirname, './src'),
-        },
-    },
-    optimizeDeps: {
-        exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"],
-    },
+  plugins: [tailwindcss(), react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
+  optimizeDeps: {
+    exclude: ["@ffmpeg/ffmpeg", "@ffmpeg/util"]
+  }
 });


### PR DESCRIPTION
## Summary
- Swapped the app's accent palette from amber/teal to indigo/periwinkle across theme variables, menus, tabs, buttons, and headings
- Restyled messages into dark-navy cards: header with right-aligned timestamp and hover actions, reply quote, two-line file attachment card, clean URL preview card, subtle thread-button pill
- Redesigned the message editor as a single rounded card: attachment icons (mic/video/file) on the left, borderless auto-expanding multiline textarea, square indigo icon send button
- Multiline input: Enter sends, Ctrl+Enter / Shift+Enter insert a newline; messages render line breaks
- Reply preview above the input shows avatar, uppercase author, timestamp, and italic quoted text
- Thread panel is now visually separated: tinted surface, left border, icon + title header with right-aligned close button
- Timestamps show time only (HH:mm) for messages from the last 24 hours
- "(edited)" label moved next to the timestamp

## Verification
- `npm run build` passes
- Verified at runtime with Playwright screenshots: message cards, reactions, reply quotes, URL previews, PDF attachment card, multiline typing/sending/editing, thread panel, and the new editor in both channel and thread views

🤖 Generated with [Claude Code](https://claude.com/claude-code)